### PR TITLE
Update packages & links

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -123,7 +123,7 @@ fi
 
 
 if build "opencore"; then
-	download "http://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fopencore-amr%2Ffiles%2Fopencore-amr%2F&ts=1442256558&use_mirror=netassist" "opencore-amr-0.1.3.tar.gz"
+	download "http://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.3.tar.gz" "opencore-amr-0.1.3.tar.gz"
 	cd $PACKAGES/opencore-amr-0.1.3 
 	execute ./configure --prefix=${WORKSPACE} --disable-shared --enable-static 
 	execute make -j 4 
@@ -238,8 +238,8 @@ if build "vid_stab"; then
 fi
 
 if build "x265"; then
-	download "https://bitbucket.org/multicoreware/x265/downloads/x265_1.9.tar.gz" "x265-1.9.tar.gz"
-	cd $PACKAGES/x265_1.9
+	download "https://bitbucket.org/multicoreware/x265/get/1.6.tar.gz" "x265-1.9.tar.gz"
+	cd $PACKAGES/multicoreware*
 	cd source
 	execute cmake -DCMAKE_INSTALL_PREFIX:PATH=${WORKSPACE} -DENABLE_SHARED:bool=off . 
 	execute make -j 4
@@ -250,8 +250,7 @@ if build "x265"; then
 fi
 
 if build "fdk_aac"; then
-	# download "http://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.3.tar.gz" "fdk-aac-0.1.3.tar.gz"
-	download "http://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fopencore-amr%2Ffiles%2Ffdk-aac%2F&ts=1457561564&use_mirror=kent" "fdk-aac-0.1.4.tar.gz"
+	download "http://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz" "fdk-aac-0.1.4.tar.gz"
 	
 	cd $PACKAGES/fdk-aac*
 	execute ./configure --prefix=${WORKSPACE} --disable-shared --enable-static

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -238,7 +238,7 @@ if build "vid_stab"; then
 fi
 
 if build "x265"; then
-	download "https://bitbucket.org/multicoreware/x265/get/1.6.tar.gz" "x265-1.9.tar.gz"
+	download "https://bitbucket.org/multicoreware/x265/get/1.9.tar.gz" "x265-1.9.tar.gz"
 	cd $PACKAGES/multicoreware*
 	cd source
 	execute cmake -DCMAKE_INSTALL_PREFIX:PATH=${WORKSPACE} -DENABLE_SHARED:bool=off . 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -187,8 +187,8 @@ fi
 
 
 if build "libvorbis"; then
-	download "http://downloads.xiph.org/releases/vorbis/libvorbis-1.4.0.tar.gz" "libvorbis-1.4.0.tar.gz"
-	cd $PACKAGES/libvorbis-1.4.0
+	download "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz" "libvorbis-1.3.5.tar.gz"
+	cd $PACKAGES/libvorbis-1.3.5
 	execute ./configure --prefix=${WORKSPACE} --with-ogg-libraries=${WORKSPACE}/lib --with-ogg-includes=${WORKSPACE}/include/ --enable-static --disable-shared --disable-oggtest
 	execute make -j 4
 	execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # http://www.github.com/markus-perl
-# Version 0.1
+# Version 0.2
 
 CWD=`pwd`
 PACKAGES="$CWD/packages" 
@@ -123,7 +123,7 @@ fi
 
 
 if build "opencore"; then
-	download "http://garr.dl.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.3.tar.gz" "opencore-amr-0.1.3.tar.gz"
+	download "http://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.3.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fopencore-amr%2Ffiles%2Fopencore-amr%2F&ts=1442256558&use_mirror=netassist" "opencore-amr-0.1.3.tar.gz"
 	cd $PACKAGES/opencore-amr-0.1.3 
 	execute ./configure --prefix=${WORKSPACE} --disable-shared --enable-static 
 	execute make -j 4 
@@ -132,8 +132,9 @@ if build "opencore"; then
 fi
 
 if build "libvpx"; then
-	download "http://webm.googlecode.com/files/libvpx-v1.3.0.tar.bz2" "libvpx-v1.3.0.tar.bz2" 
-	cd $PACKAGES/libvpx-v1.3.0 
+	download "https://github.com/webmproject/libvpx/archive/v1.5.0.tar.gz" "libvpx-1.5.0.tar.gz" 
+	cd $PACKAGES/libvpx* 
+	sed   -e 's/cp -p/cp/' -i build/make/Makefile
 	execute ./configure --prefix=${WORKSPACE} --disable-unit-tests --disable-shared
 	execute make -j 4
 	execute make install
@@ -186,8 +187,8 @@ fi
 
 
 if build "libvorbis"; then
-	download "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.4.tar.gz" "libvorbis-1.3.4.tar.gz"
-	cd $PACKAGES/libvorbis-1.3.4 
+	download "http://downloads.xiph.org/releases/vorbis/libvorbis-1.4.0.tar.gz" "libvorbis-1.4.0.tar.gz"
+	cd $PACKAGES/libvorbis-1.4.0
 	execute ./configure --prefix=${WORKSPACE} --with-ogg-libraries=${WORKSPACE}/lib --with-ogg-includes=${WORKSPACE}/include/ --enable-static --disable-shared --disable-oggtest
 	execute make -j 4
 	execute make install
@@ -207,8 +208,8 @@ if build "libtheora"; then
 fi
 
 if build "pkg-config"; then
-	download "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz" "pkg-config-0.28.tar.gz"
-	cd $PACKAGES/pkg-config-0.28 
+	download "http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz" "pkg-config-0.29.tar.gz"
+	cd $PACKAGES/pkg-config-0.29 
 	execute ./configure --silent --prefix=${WORKSPACE} --with-pc-path=${WORKSPACE}/lib/pkgconfig --with-internal-glib
 	execute make -j 4
 	execute make install
@@ -216,7 +217,7 @@ if build "pkg-config"; then
 fi
 
 if build "cmake"; then
-	download "http://www.cmake.org/files/v3.0/cmake-3.0.2.tar.gz" "cmake-3.0.2.tar.gz"
+	download "https://cmake.org/files/v3.5/cmake-3.5.0.tar.gz" "cmake-3.5.0.tar.gz"
 	cd $PACKAGES/cmake* 
 	rm Modules/FindJava.cmake
 	perl -p -i -e "s/get_filename_component.JNIPATH/#get_filename_component(JNIPATH/g" Tests/CMakeLists.txt 
@@ -237,10 +238,10 @@ if build "vid_stab"; then
 fi
 
 if build "x265"; then
-	download "https://bitbucket.org/multicoreware/x265/get/1.6.tar.gz" "x265-1.6.tar.gz"
-	cd $PACKAGES/multicoreware*
+	download "https://bitbucket.org/multicoreware/x265/downloads/x265_1.9.tar.gz" "x265-1.9.tar.gz"
+	cd $PACKAGES/x265_1.9
 	cd source
-	execute cmake -DCMAKE_INSTALL_PREFIX:PATH=${WORKSPACE} -DENABLE_SHARED=NO .
+	execute cmake -DCMAKE_INSTALL_PREFIX:PATH=${WORKSPACE} -DENABLE_SHARED:bool=off . 
 	execute make -j 4
 	execute make install
 	sed "s/-lx265/-lx265 -lstdc++/g" "$WORKSPACE/lib/pkgconfig/x265.pc" > "$WORKSPACE/lib/pkgconfig/x265.pc.tmp"
@@ -250,7 +251,7 @@ fi
 
 if build "fdk_aac"; then
 	# download "http://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.3.tar.gz" "fdk-aac-0.1.3.tar.gz"
-	download "http://ftp.cc.uoc.gr/mirrors/linux/lfs/LFS/7.6/f/fdk-aac-0.1.3.tar.gz" "fdk-aac-0.1.3.tar.gz"
+	download "http://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fopencore-amr%2Ffiles%2Ffdk-aac%2F&ts=1457561564&use_mirror=kent" "fdk-aac-0.1.4.tar.gz"
 	
 	cd $PACKAGES/fdk-aac*
 	execute ./configure --prefix=${WORKSPACE} --disable-shared --enable-static


### PR DESCRIPTION
* opencore download fixed
* libvpx upgraded from 1.3.0 to 1.5.0
* libvorbis upgraded from 1.3.4 to 1.3.5
* pkg-config upgraded from 0.28 to 0.29
* cmake upgraded from 3.0.2 to 3.5.0
* x265 upgraded from 1.6 to 1.9
* fdk_aac upgraded from 0.1.3 to 0.1.4

We were already utilizing curl's redirect functionality so I changed some urls to more readable/consistent urls
-- Entire script tested today 09-03-2016 23:33, and ran without issues on Ubuntu 15.10