### PR TITLE
Fix ffmpeg-snapshot.tar.bz2 download

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -306,7 +306,7 @@ fi
 
 
 build "ffmpeg"
-download "http://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 " "ffmpeg-snapshot.tar.bz2 "
+download "http://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2" "ffmpeg-snapshot.tar.bz2"
 cd $PACKAGES/ffmpeg* || exit
 CFLAGS="-I$WORKSPACE/include" LDFLAGS="-L$WORKSPACE/lib" 
 execute ./configure  --arch=64 --prefix=${WORKSPACE} --extra-cflags="-I$WORKSPACE/include" --extra-ldflags="-L$WORKSPACE/lib" \


### PR DESCRIPTION
Extra white-space in the ffmpeg-snapshot.tar.bz2 paths (remote and local) are preventing macOS from downloading the file successfully.