### PR TITLE
Enable OpenSSL

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -335,8 +335,7 @@ execute ./configure  --arch=64 --prefix=${WORKSPACE} --extra-cflags="-I$WORKSPAC
 	--enable-libopencore_amrnb \
 	--enable-filters \
 	--enable-libvidstab \
-	--enable-openssl \
-	--enable-gnutls 
+	--enable-openssl 
 	# enable all filters
 	# enable AAC de/encoding via libfdk-aac [no]
 	# enable detecting cpu capabilities at runtime (smaller binary)

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -334,7 +334,9 @@ execute ./configure  --arch=64 --prefix=${WORKSPACE} --extra-cflags="-I$WORKSPAC
 	--enable-libopencore_amrwb \
 	--enable-libopencore_amrnb \
 	--enable-filters \
-	--enable-libvidstab 
+	--enable-libvidstab \
+	--enable-openssl \
+	--enable-gnutls 
 	# enable all filters
 	# enable AAC de/encoding via libfdk-aac [no]
 	# enable detecting cpu capabilities at runtime (smaller binary)
@@ -354,6 +356,7 @@ execute ./configure  --arch=64 --prefix=${WORKSPACE} --extra-cflags="-I$WORKSPAC
 	# build static libraries [no]
 	# disable debugging symbols
 	# disable build shared libraries [no]
+	# enable OpenSSL
 execute make -j $MJOBS
 execute make install
 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -335,7 +335,7 @@ execute ./configure  --arch=64 --prefix=${WORKSPACE} --extra-cflags="-I$WORKSPAC
 	--enable-libopencore_amrnb \
 	--enable-filters \
 	--enable-libvidstab \
-	--enable-openssl 
+	--enable-openssl
 	# enable all filters
 	# enable AAC de/encoding via libfdk-aac [no]
 	# enable detecting cpu capabilities at runtime (smaller binary)


### PR DESCRIPTION
Adds
`--enable-OpenSSL`
And
`--enable-gnutls`
To the `.configure` build. Based off the ask Ubuntu forum post here: https://askubuntu.com/questions/650577/how-to-compile-ffmpeg-with-https-support

See Request #14 to compile with OpenSSL