### PR TITLE
Added $AUTOINSTALL for usability in other scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,23 @@ Installation
 
 Open your command line and run (needs curl to be installed):
 
-```
-bash <(curl -s https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1)
+```bash
+bash <(curl -s "https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1")
 ```
 This command downloads the build script and automatically starts the build process.
 
 ### Common installation
 
-```
+```bash
 git clone https://github.com/markus-perl/ffmpeg-build-script.git
 cd ffmpeg-build-script
-./ffmpeg-build-script --help
+./build-ffmpeg --help
 ```
 
 Usage
 ------
 
-```
+```bash
 ./build-ffmpeg --help       Display usage information
 ./build-ffmpeg --build      Starts the build process
 ./build-ffmpeg --cleanup    Remove all working dirs

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -384,7 +384,13 @@ echo "Building done. The binary can be found here: $WORKSPACE/bin/ffmpeg"
 echo ""
 
 
-if [[ ! $SKIPINSTALL == "yes" ]]; then
+if [[ $AUTOINSTALL == "yes" ]]; then
+	if command_exists "sudo"; then
+		sudo cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
+		sudo cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
+		echo "Done. ffmpeg is now installed to your system"
+	fi
+elif [[ ! $SKIPINSTALL == "yes" ]]; then
 	if command_exists "sudo"; then
 
 		read -r -p "Install the binary to your $INSTALL_FOLDER folder? [Y/n] " response


### PR DESCRIPTION
* Added an optional AUTOINSTALL parameter that makes it easier to integrate this script in other scripts for automation (user need not wait to press yes when asked. 
* Fixed outdated build command in the "Common Installation" section of `README.md`
* Added URL within quotes for the one-command-installation so that it can be used in other shells like `zsh` which would throw the following error otherwise
```bash
$ bash <(curl -s https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1)

zsh: no matches found: https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1
```