### PR TITLE
don't build libtheora spec

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -272,7 +272,7 @@ if build "libtheora"; then
 	sed "s/-fforce-addr//g" configure > configure.patched
 	chmod +x configure.patched
 	mv configure.patched configure
-	execute ./configure --prefix=${WORKSPACE} --with-ogg-libraries=${WORKSPACE}/lib --with-ogg-includes=${WORKSPACE}/include/ --with-vorbis-libraries=${WORKSPACE}/lib --with-vorbis-includes=${WORKSPACE}/include/ --enable-static --disable-shared --disable-oggtest --disable-vorbistest --disable-examples --disable-asm
+	execute ./configure --prefix=${WORKSPACE} --with-ogg-libraries=${WORKSPACE}/lib --with-ogg-includes=${WORKSPACE}/include/ --with-vorbis-libraries=${WORKSPACE}/lib --with-vorbis-includes=${WORKSPACE}/include/ --enable-static --disable-shared --disable-oggtest --disable-vorbistest --disable-examples --disable-asm --disable-spec
 	execute make -j $MJOBS
 	execute make install
 	build_done "libtheora"


### PR DESCRIPTION
no need to build the spec, plus on debian, it often fails to build
with:

/cmti7.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/amsfonts/cm/cmtt10
.pfb>
Output written on spec.pdf (202 pages, 650157 bytes).
Transcript written on spec.log.
Makefile:454: recipe for target 'Theora.pdf' failed
make[3]: *** [Theora.pdf] Error 1
make[3]: Leaving directory '/home/jason/source/ffmpeg-build-script/packages/libtheora-1.1.1/doc/spec'
Makefile:236: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory '/home/jason/source/ffmpeg-build-script/packages/libtheora-1.1.1/doc'
Makefile:291: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/jason/source/ffmpeg-build-script/packages/libtheora-1.1.1'
Makefile:205: recipe for target 'all' failed
make: *** [all] Error 2

Failed to Execute make -j 16