### PR TITLE
Openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.10
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates \
+    && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -43,7 +43,7 @@ remove_dir () {
 download () {
 
 	DOWNLOAD_PATH=$PACKAGES;
-		
+
 	if [ ! -z "$3" ]; then
 		mkdir -p $PACKAGES/$3
 		DOWNLOAD_PATH=$PACKAGES/$3
@@ -340,6 +340,15 @@ if build "av1"; then
 	build_done "av1"
 fi
 
+if build "openssl"; then
+	download "https://www.openssl.org/source/openssl-1.1.1c.tar.gz" "openssl-1.1.1c.tar.gz"
+	cd $PACKAGES/openssl-1.1.1c || exit
+	execute ./config --prefix=${WORKSPACE} --openssldir=${WORKSPACE} shared zlib
+	execute make -j $MJOBS
+	execute make install
+	build_done "openssl"
+fi
+
 build "ffmpeg"
 download "https://ffmpeg.org/releases/ffmpeg-4.2.tar.bz2" "ffmpeg-snapshot.tar.bz2"
 cd $PACKAGES/ffmpeg-4.2 || exit
@@ -355,6 +364,7 @@ cd $PACKAGES/ffmpeg-4.2 || exit
 	--disable-shared \
 	--disable-ffplay \
 	--disable-doc \
+	--enable-openssl \
 	--enable-gpl \
 	--enable-version3 \
 	--enable-nonfree \


### PR DESCRIPTION
At some point ffmpeg seems to have moved openssl out. So the current build script can't handle https sources.

to reproduce:

docker run  ffmpeg -i https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4 -f webm -c:v libvpx -c:a libvorbis - > /tmp/test.mp4

Here is a PR where I added a openssl build step, the dependency install for the Dockerfile and the --enable-openssl configuration.
