### PR TITLE
nvcodec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ because I don't have the resources and the time to maintain other systems.
 * ogg: Free, open container format
 * vorbis: Lossy audio compression format
 * theora: Free lossy video compression format
+* opus: Lossy audio coding format
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with https://travis-ci.org just to make sure everything works as expected.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ because I don't have the resources and the time to maintain other systems.
 * `vorbis`: Lossy audio compression format
 * `theora`: Free lossy video compression format
 * `opus`: Lossy audio coding format
-* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected
+* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected, follow [these](#Cuda-installation) instructions for installation
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with https://travis-ci.org just to make sure everything works as expected.
@@ -82,6 +82,11 @@ git clone https://github.com/markus-perl/ffmpeg-build-script.git
 cd ffmpeg-build-script
 ./build-ffmpeg --help
 ```
+
+
+### Cuda installation
+
+To be able to install CUDA, you first need a compatible NVIDIA GPU.  Once you have the GPU and display driver installed, you can follow the [official instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) or [this blog](https://www.pugetsystems.com/labs/hpc/How-To-Install-CUDA-10-1-on-Ubuntu-19-04-1405/) to setup CUDA
 
 Usage
 ------

--- a/README.md
+++ b/README.md
@@ -20,17 +20,18 @@ because I don't have the resources and the time to maintain other systems.
 
 
 ## Supported Codecs
-* x264: H.264 (MPEG-4 AVC)
-* x265: H.265 Video Codec
-* aom: AV1 Video Codec (Experimental and very slow!)
-* fdk_aac: Fraunhofer FDK AAC Codec 
-* xvidcore: MPEG-4 video coding standard
-* webm: WebM is a video file format
-* mp3: MPEG-1 or MPEG-2 Audio Layer III
-* ogg: Free, open container format
-* vorbis: Lossy audio compression format
-* theora: Free lossy video compression format
-* opus: Lossy audio coding format
+* `x264`: H.264 (MPEG-4 AVC)
+* `x265`: H.265 Video Codec
+* `aom`: AV1 Video Codec (Experimental and very slow!)
+* `fdk_aac`: Fraunhofer FDK AAC Codec 
+* `xvidcore`: MPEG-4 video coding standard
+* `webm`: WebM is a video file format
+* `mp3`: MPEG-1 or MPEG-2 Audio Layer III
+* `ogg`: Free, open container format
+* `vorbis`: Lossy audio compression format
+* `theora`: Free lossy video compression format
+* `opus`: Lossy audio coding format
+* `nv-codec`: NVIDIA's GPU accelerated video codecs(H264 and HEVC). Installation is triggered only if CUDA installation is detected
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with https://travis-ci.org just to make sure everything works as expected.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ffmpeg-build-script is rockstable. Every commit runs against Linux and OSX with 
 Requirements OSX
 ------------
 
-* XCode 8.x or greater
+* XCode 10.x or greater
 
 Requirements Linux
 ------------
@@ -99,8 +99,8 @@ Contact
 Tested on
 ---------
 
-* Mac OSX 10.14 64Bit XCode 10.1
-* Debian 9.4
+* Mac OSX 10.14 64Bit XCode 11.0
+* Debian 9.11
 
 Example
 -------

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -2,7 +2,7 @@
 
 # https://github.com/markus-perl/ffmpeg-build-script
 
-VERSION=1.6
+VERSION=1.7
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"
@@ -217,6 +217,15 @@ if build "lame"; then
 	build_done "lame"
 fi
 
+if build "opus"; then
+	download "https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz" "opus-1.3.1.tar.gz"
+	cd $PACKAGES/opus-1.3.1 || exit
+	execute ./configure --prefix=${WORKSPACE} --disable-shared --enable-static
+	execute make -j $MJOBS
+	execute make install
+	build_done "opus"
+fi
+
 if build "xvidcore"; then
 	download "https://downloads.xvid.com/downloads/xvidcore-1.3.5.tar.gz" "xvidcore-1.3.5.tar.gz"
 	cd $PACKAGES/xvidcore  || exit
@@ -380,6 +389,7 @@ cd $PACKAGES/ffmpeg-6023b9f/ || exit
 	--enable-pthreads \
 	--enable-libvpx \
 	--enable-libmp3lame \
+    --enable-libopus \
 	--enable-libtheora \
 	--enable-libvorbis \
 	--enable-libx264 \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -233,7 +233,7 @@ if build "xvidcore"; then
 fi
 
 if build "x264"; then
-	download "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20190806-2245-stable.tar.bz2" "last_x264.tar.bz2"
+	download "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20191008-2245-stable.tar.bz2" "last_x264.tar.bz2"
 	cd $PACKAGES/x264-snapshot-* || exit
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -309,7 +309,7 @@ if build "vid_stab"; then
 fi
 
 if build "x265"; then
-	download "https://bitbucket.org/multicoreware/x265/downloads/x265_3.1.2.tar.gz" "x265-3.1.2.tar.gz"
+	download "https://bitbucket.org/multicoreware/x265/downloads/x265_3.2.tar.gz" "x265-3.2.tar.gz"
 	cd $PACKAGES/x265_* || exit
 	cd source || exit
 	execute cmake -DCMAKE_INSTALL_PREFIX:PATH=${WORKSPACE} -DENABLE_SHARED:bool=off .
@@ -350,8 +350,8 @@ if build "zlib"; then
 fi
 
 if build "openssl"; then
-	download "https://www.openssl.org/source/openssl-1.1.1c.tar.gz" "openssl-1.1.1c.tar.gz"
-	cd $PACKAGES/openssl-1.1.1c || exit
+	download "https://www.openssl.org/source/openssl-1.1.1d.tar.gz" "openssl-1.1.1d.tar.gz"
+	cd $PACKAGES/openssl-1.1.1d || exit
 	execute ./config --prefix=${WORKSPACE} --openssldir=${WORKSPACE} --with-zlib-include=${WORKSPACE}/include/ --with-zlib-lib=${WORKSPACE}/lib no-shared zlib
 	execute make -j $MJOBS
 	execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -367,6 +367,19 @@ if build "openssl"; then
 	build_done "openssl"
 fi
 
+if which nvcc > /dev/null ; then
+       if build "nv-codec"; then
+               download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n9.1.23.0/nv-codec-headers-9.1.23.0.tar.gz" "nv-codec-headers-9.1.23.0.tar.gz"
+               cd $PACKAGES/nv-codec-headers-n9.1.23.0 || exit
+               sed -i  "s#PREFIX = /usr/local#PREFIX = ${WORKSPACE}#g" $PACKAGES/nv-codec-headers-n9.1.23.0/Makefile
+               execute make install
+               build_done "nv-codec"
+       fi
+       CFLAGS="$CFLAGS -I/usr/local/cuda/include"
+       LDFLAGS="$LDFLAGS -L/usr/local/cuda/lib64"
+       ADDITIONAL_CONFIGURE_OPTIONS="$ADDITIONAL_CONFIGURE_OPTIONS --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-libnpp"
+fi
+
 build "ffmpeg"
 download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/6023b9fbfef02b71f6acfb1b09e5a12fe9d276e2.tar.gz" "ffmpeg-snapshot.tar.bz2"
 cd $PACKAGES/ffmpeg-6023b9f/ || exit
@@ -374,8 +387,8 @@ cd $PACKAGES/ffmpeg-6023b9f/ || exit
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \
     --pkg-config-flags="--static" \
-    --extra-cflags="-I$WORKSPACE/include" \
-    --extra-ldflags="-L$WORKSPACE/lib" \
+    --extra-cflags="$CFLAGS" \
+    --extra-ldflags="$LDFLAGS" \
     --extra-libs="-lpthread -lm" \
 	--enable-static \
 	--disable-debug \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -288,8 +288,8 @@ if build "pkg-config"; then
 fi
 
 if build "cmake"; then
-	download "https://cmake.org/files/v3.11/cmake-3.11.3.tar.gz" "cmake-3.11.3.tar.gz"
-	cd $PACKAGES/cmake-3.11.3  || exit
+	download "https://cmake.org/files/v3.15/cmake-3.15.4.tar.gz" "cmake-3.15.4.tar.gz"
+	cd $PACKAGES/cmake-3.15.4  || exit
 	rm Modules/FindJava.cmake
 	perl -p -i -e "s/get_filename_component.JNIPATH/#get_filename_component(JNIPATH/g" Tests/CMakeLists.txt
 	perl -p -i -e "s/get_filename_component.JNIPATH/#get_filename_component(JNIPATH/g" Tests/CMakeLists.txt
@@ -330,7 +330,7 @@ if build "fdk_aac"; then
 fi
 
 if build "av1"; then
-	download "https://aomedia.googlesource.com/aom/+archive/8d335b714326a38dd6d20403082f1c8eb2c3f7e5.tar.gz" "av1.tar.gz" "av1"
+	download "https://aomedia.googlesource.com/aom/+archive/60a00de69ca79fe5f51dcbf862aaaa8eb50ec344.tar.gz" "av1.tar.gz" "av1"
 	cd $PACKAGES/av1 || exit
 	mkdir -p $PACKAGES/aom_build
 	cd $PACKAGES/aom_build
@@ -359,8 +359,8 @@ if build "openssl"; then
 fi
 
 build "ffmpeg"
-download "https://ffmpeg.org/releases/ffmpeg-4.2.tar.bz2" "ffmpeg-snapshot.tar.bz2"
-cd $PACKAGES/ffmpeg-4.2 || exit
+download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/6023b9fbfef02b71f6acfb1b09e5a12fe9d276e2.tar.gz" "ffmpeg-snapshot.tar.bz2"
+cd $PACKAGES/ffmpeg-6023b9f/ || exit
 ./configure $ADDITIONAL_CONFIGURE_OPTIONS \
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -2,7 +2,7 @@
 
 # https://github.com/markus-perl/ffmpeg-build-script
 
-VERSION=1.5
+VERSION=1.6
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"


### PR DESCRIPTION
Support for nvenc and nvdec for Nvidia GPU-Accelerated encoding and decoding.

Installs only if a valid version of CUDA is detected. Steps follow [this guide](https://developer.nvidia.com/ffmpeg) with the addition of the `sed` line to ensure that `sudo` permissions are not needed, and that it is a local copy.