### PR TITLE
Make --disable-doc optional and other changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+ARG CLEANUP="yes"
+FROM ubuntu:20.04 AS base
 ARG MAKE_DOCS="no"
 
 RUN apt-get update \
@@ -12,7 +13,12 @@ COPY ./build-ffmpeg /app/build-ffmpeg
 RUN AUTOINSTALL=yes /app/build-ffmpeg --build
 RUN cp /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
 RUN cp /app/workspace/bin/ffprobe /usr/bin/ffprobe
+
+FROM base as cleanup-no
+FROM base as cleanup-yes
 RUN /app/build-ffmpeg --cleanup
+
+FROM cleanup-${CLEANUP} AS final
 
 CMD         ["--help"]
 ENTRYPOINT  ["/usr/bin/ffmpeg"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:20.04
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update \
 WORKDIR /app
 COPY ./build-ffmpeg /app/build-ffmpeg
 
-RUN AUTOINSTALL=yes /app/build-ffmpeg --build
-RUN cp /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
-RUN cp /app/workspace/bin/ffprobe /usr/bin/ffprobe
+RUN SKIP_FFMPEG_BUILD=yes /app/build-ffmpeg --build
+RUN AUTOINSTALL=yes /app/build-ffmpeg --build  # change comment to trigger layer rebuild
+RUN cp /app/workspace/bin/ffmpeg /app/workspace/bin/ffprobe /usr/bin/
 
 FROM base as cleanup-no
 FROM base as cleanup-yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,15 @@ FROM ubuntu:20.04 AS base
 ARG MAKE_DOCS="no"
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev m4 \
+    && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 
 WORKDIR /app
 COPY ./build-ffmpeg /app/build-ffmpeg
 
-RUN STOP_BEFORE_CMAKE=yes /app/build-ffmpeg --build
-RUN STOP_BEFORE_GNUTLS=yes /app/build-ffmpeg --build
 RUN SKIP_FFMPEG_BUILD=yes /app/build-ffmpeg --build
-RUN AUTOINSTALL=yes /app/build-ffmpeg --build  # toggle comment to trigger layer rebuild
+RUN AUTOINSTALL=yes /app/build-ffmpeg --build  # change comment to trigger layer rebuild
 RUN cp /app/workspace/bin/ffmpeg /app/workspace/bin/ffprobe /usr/bin/
 
 FROM base as cleanup-no

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,17 @@ FROM ubuntu:20.04 AS base
 ARG MAKE_DOCS="no"
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev \
+    && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev m4 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 
 WORKDIR /app
 COPY ./build-ffmpeg /app/build-ffmpeg
 
+RUN STOP_BEFORE_CMAKE=yes /app/build-ffmpeg --build
+RUN STOP_BEFORE_GNUTLS=yes /app/build-ffmpeg --build
 RUN SKIP_FFMPEG_BUILD=yes /app/build-ffmpeg --build
-RUN AUTOINSTALL=yes /app/build-ffmpeg --build  # change comment to trigger layer rebuild
+RUN AUTOINSTALL=yes /app/build-ffmpeg --build  # toggle comment to trigger layer rebuild
 RUN cp /app/workspace/bin/ffmpeg /app/workspace/bin/ffprobe /usr/bin/
 
 FROM base as cleanup-no

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:20.04
+ARG MAKE_DOCS="no"
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install  build-essential curl g++ ca-certificates libz-dev \

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,0 +1,26 @@
+ARG CLEANUP="yes"
+FROM centos:7 AS base
+ARG MAKE_DOCS="no"
+
+RUN yum update -y && \
+    yum install -y autoconf automake bzip2 bzip2-devel freetype-devel gcc gcc-c++ git libtool make mercurial && \
+    yum install -y vim
+
+#      yum install autoconf automake bzip2 bzip2-devel cmake freetype-devel gcc gcc-c++ git libtool make mercurial pkgconfig zlib-devel
+
+WORKDIR /app
+COPY ./build-ffmpeg /app/build-ffmpeg
+
+RUN STOP_BEFORE_CMAKE=yes /app/build-ffmpeg --build
+RUN SKIP_FFMPEG_BUILD=yes /app/build-ffmpeg --build
+RUN AUTOINSTALL=yes /app/build-ffmpeg --build  # toggle comment to trigger layer rebuild
+RUN cp /app/workspace/bin/ffmpeg /app/workspace/bin/ffprobe /usr/bin/
+
+FROM base as cleanup-no
+FROM base as cleanup-yes
+RUN /app/build-ffmpeg --cleanup
+
+FROM cleanup-${CLEANUP} AS final
+
+CMD         ["--help"]
+ENTRYPOINT  ["/usr/bin/ffmpeg"]

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # https://github.com/markus-perl/ffmpeg-build-script
-# statically linking glibc is limited and will break DNS unless the right NSS calls can be dynamically loaded e.g. getaddrinfo, getpwuid_r
 
 VERSION=1.11
 CWD=$(pwd)
@@ -247,9 +246,9 @@ if build "x264"; then
 	cd "$PACKAGES"/x264-stable || exit
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
-		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic --disable-opencl CXXFLAGS="-fPIC"
+		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC"
     else
-        execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic --disable-opencl
+        execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
     fi
 
     execute make -j $MJOBS
@@ -297,10 +296,6 @@ if build "pkg-config"; then
 	build_done "pkg-config"
 fi
 
-if [[ $STOP_BEFORE_CMAKE == "yes" ]]; then
-  exit 0
-fi
-
 if build "cmake"; then
 	download "https://cmake.org/files/v3.15/cmake-3.15.4.tar.gz" "cmake-3.15.4.tar.gz"
 	cd "$PACKAGES"/cmake-3.15.4  || exit
@@ -326,10 +321,10 @@ if build "x265"; then
 	download "https://bitbucket.org/multicoreware/x265/downloads/x265_3.3.tar.gz" "x265-3.3.tar.gz"
 	cd "$PACKAGES"/x265_* || exit
 	cd source || exit
-	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON -DENABLE_CLI:BOOL=OFF -DEXPORT_C_API=OFF .
+	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off .
 	execute make -j $MJOBS
 	execute make install
-	sed "s/-lgcc_s/-lgcc_eh/g" "$WORKSPACE/lib/pkgconfig/x265.pc" > "$WORKSPACE/lib/pkgconfig/x265.pc.tmp"
+	sed "s/-lx265/-lx265 -lstdc++/g" "$WORKSPACE/lib/pkgconfig/x265.pc" > "$WORKSPACE/lib/pkgconfig/x265.pc.tmp"
 	mv "$WORKSPACE/lib/pkgconfig/x265.pc.tmp" "$WORKSPACE/lib/pkgconfig/x265.pc"
 	build_done "x265"
 fi
@@ -363,35 +358,13 @@ if build "zlib"; then
 	build_done "zlib"
 fi
 
-if [[ $STOP_BEFORE_GNUTLS == "yes" ]]; then
-  exit 0
-fi
-
-if build "gmplib"; then
-	download "https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz" "gmp-6.2.0.tar.xz"
-	cd "$PACKAGES"/gmp-6.2.0 || exit
-	execute ./configure --prefix="${WORKSPACE}" --disable-shared
+if build "openssl"; then
+	download "https://www.openssl.org/source/openssl-1.1.1g.tar.gz" "openssl-1.1.1g.tar.gz"
+	cd "$PACKAGES"/openssl-1.1.1g || exit
+	execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib
 	execute make -j $MJOBS
 	execute make install
-	build_done "gmplib"
-fi
-
-if build "nettle"; then
-	download "https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz" "nettle-3.6.tar.gz"
-	cd "$PACKAGES"/nettle-3.6 || exit
-	execute ./configure --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib --with-lib-path="${WORKSPACE}"/lib --with-include-path="${WORKSPACE}"/include --disable-shared
-	execute make -j $MJOBS
-	execute make install
-	build_done "nettle"
-fi
-
-if build "gnutls"; then
-	download "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz" "gnutls-3.6.14.tar.xz"
-	cd "$PACKAGES"/gnutls-3.6.14 || exit
-	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static --with-included-unistring --with-included-libtasn1 --without-p11-kit --disable-doc --disable-cxx --disable-tools LDFLAGS="-L${WORKSPACE}/lib"
-	execute make -j $MJOBS
-	execute make install
-	build_done "gnutls"
+	build_done "openssl"
 fi
 
 CFLAGS="-I$WORKSPACE/include"
@@ -422,14 +395,14 @@ cd "$PACKAGES"/ffmpeg-192d1d3/ || exit
     --prefix="${WORKSPACE}" \
     --pkg-config-flags="--static" \
     --extra-cflags="$CFLAGS" \
-    --extra-ldflags="$LDFLAGS -static -static-libstdc++ -static-libgcc" \
+    --extra-ldflags="$LDFLAGS" \
     --extra-libs="-lpthread -lm" \
 	--enable-static \
 	--disable-debug \
 	--disable-shared \
 	--disable-ffplay \
 	$(if [[ $MAKE_DOCS != "yes" ]]; then echo --disable-doc; fi) \
-	--enable-gnutls \
+	--enable-openssl \
 	--enable-gpl \
 	--enable-version3 \
 	--enable-nonfree \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -397,7 +397,7 @@ cd "$PACKAGES"/ffmpeg-192d1d3/ || exit
 	--disable-debug \
 	--disable-shared \
 	--disable-ffplay \
-	--disable-doc \
+	$(if [[ $MAKE_DOCS != "yes" ]]; then echo --disable-doc; fi) \
 	--enable-openssl \
 	--enable-gpl \
 	--enable-version3 \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -382,6 +382,10 @@ if command -v nvcc > /dev/null ; then
        ADDITIONAL_CONFIGURE_OPTIONS="$ADDITIONAL_CONFIGURE_OPTIONS --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-libnpp"
 fi
 
+if [[ $SKIP_FFMPEG_BUILD == "yes" ]]; then
+  exit 0
+fi
+
 build "ffmpeg"
 download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/192d1d34eb3668fa27f433e96036340e1e5077a0.tar.gz" "ffmpeg-snapshot.tar.bz2"
 cd "$PACKAGES"/ffmpeg-192d1d3/ || exit

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -296,6 +296,10 @@ if build "pkg-config"; then
 	build_done "pkg-config"
 fi
 
+if [[ $STOP_BEFORE_CMAKE == "yes" ]]; then
+  exit 0
+fi
+
 if build "cmake"; then
 	download "https://cmake.org/files/v3.15/cmake-3.15.4.tar.gz" "cmake-3.15.4.tar.gz"
 	cd "$PACKAGES"/cmake-3.15.4  || exit
@@ -343,7 +347,7 @@ if build "av1"; then
 	cd "$PACKAGES"/av1 || exit
 	mkdir -p "$PACKAGES"/aom_build
 	cd "$PACKAGES"/aom_build || exit
-	execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" "$PACKAGES"/av1
+	execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib "$PACKAGES"/av1
 	execute make -j $MJOBS
 	execute make install
 	build_done "av1"

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # https://github.com/markus-perl/ffmpeg-build-script
+# statically linking glibc is limited and will break DNS unless the right NSS calls can be dynamically loaded e.g. getaddrinfo, getpwuid_r
 
 VERSION=1.11
 CWD=$(pwd)
@@ -246,9 +247,9 @@ if build "x264"; then
 	cd "$PACKAGES"/x264-stable || exit
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
-		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC"
+		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic --disable-opencl CXXFLAGS="-fPIC"
     else
-        execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
+        execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic --disable-opencl
     fi
 
     execute make -j $MJOBS
@@ -296,6 +297,10 @@ if build "pkg-config"; then
 	build_done "pkg-config"
 fi
 
+if [[ $STOP_BEFORE_CMAKE == "yes" ]]; then
+  exit 0
+fi
+
 if build "cmake"; then
 	download "https://cmake.org/files/v3.15/cmake-3.15.4.tar.gz" "cmake-3.15.4.tar.gz"
 	cd "$PACKAGES"/cmake-3.15.4  || exit
@@ -321,10 +326,10 @@ if build "x265"; then
 	download "https://bitbucket.org/multicoreware/x265/downloads/x265_3.3.tar.gz" "x265-3.3.tar.gz"
 	cd "$PACKAGES"/x265_* || exit
 	cd source || exit
-	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off .
+	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON -DENABLE_CLI:BOOL=OFF -DEXPORT_C_API=OFF .
 	execute make -j $MJOBS
 	execute make install
-	sed "s/-lx265/-lx265 -lstdc++/g" "$WORKSPACE/lib/pkgconfig/x265.pc" > "$WORKSPACE/lib/pkgconfig/x265.pc.tmp"
+	sed "s/-lgcc_s/-lgcc_eh/g" "$WORKSPACE/lib/pkgconfig/x265.pc" > "$WORKSPACE/lib/pkgconfig/x265.pc.tmp"
 	mv "$WORKSPACE/lib/pkgconfig/x265.pc.tmp" "$WORKSPACE/lib/pkgconfig/x265.pc"
 	build_done "x265"
 fi
@@ -358,13 +363,35 @@ if build "zlib"; then
 	build_done "zlib"
 fi
 
-if build "openssl"; then
-	download "https://www.openssl.org/source/openssl-1.1.1g.tar.gz" "openssl-1.1.1g.tar.gz"
-	cd "$PACKAGES"/openssl-1.1.1g || exit
-	execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib
+if [[ $STOP_BEFORE_GNUTLS == "yes" ]]; then
+  exit 0
+fi
+
+if build "gmplib"; then
+	download "https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz" "gmp-6.2.0.tar.xz"
+	cd "$PACKAGES"/gmp-6.2.0 || exit
+	execute ./configure --prefix="${WORKSPACE}" --disable-shared
 	execute make -j $MJOBS
 	execute make install
-	build_done "openssl"
+	build_done "gmplib"
+fi
+
+if build "nettle"; then
+	download "https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz" "nettle-3.6.tar.gz"
+	cd "$PACKAGES"/nettle-3.6 || exit
+	execute ./configure --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib --with-lib-path="${WORKSPACE}"/lib --with-include-path="${WORKSPACE}"/include --disable-shared
+	execute make -j $MJOBS
+	execute make install
+	build_done "nettle"
+fi
+
+if build "gnutls"; then
+	download "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz" "gnutls-3.6.14.tar.xz"
+	cd "$PACKAGES"/gnutls-3.6.14 || exit
+	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static --with-included-unistring --with-included-libtasn1 --without-p11-kit --disable-doc --disable-cxx --disable-tools LDFLAGS="-L${WORKSPACE}/lib"
+	execute make -j $MJOBS
+	execute make install
+	build_done "gnutls"
 fi
 
 CFLAGS="-I$WORKSPACE/include"
@@ -395,14 +422,14 @@ cd "$PACKAGES"/ffmpeg-192d1d3/ || exit
     --prefix="${WORKSPACE}" \
     --pkg-config-flags="--static" \
     --extra-cflags="$CFLAGS" \
-    --extra-ldflags="$LDFLAGS" \
+    --extra-ldflags="$LDFLAGS -static -static-libstdc++ -static-libgcc" \
     --extra-libs="-lpthread -lm" \
 	--enable-static \
 	--disable-debug \
 	--disable-shared \
 	--disable-ffplay \
 	$(if [[ $MAKE_DOCS != "yes" ]]; then echo --disable-doc; fi) \
-	--enable-openssl \
+	--enable-gnutls \
 	--enable-gpl \
 	--enable-version3 \
 	--enable-nonfree \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -209,7 +209,7 @@ if build "libvpx"; then
 fi
 
 if build "lame"; then
-	download "http://kent.dl.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz" "lame-3.100.tar.gz"
+	download "https://sourceforge.net/projects/lame/files/lame/3.100/lame-3.100.tar.gz/download" "lame-3.100.tar.gz"
 	cd "$PACKAGES"/lame-3.100 || exit
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS


### PR DESCRIPTION
I'm happy to pull out any parts of this PR you don't want to include. Each commit can almost be considered in isolation.
1. Use ubuntu 20.04 as 18.10 is no longer supported
2. Pull of lame was failing from the kent mirror so I switched to the main URL
3. Allow building of the man pages as I like to include them with the binaries
4. Make cleanup optional in Dockerfile
5. Split the build into two steps in Dockerfile dependencies first then ffmpeg