### PR TITLE
Fix x265 build

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -319,7 +319,7 @@ fi
 
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/3.4.tar.gz" "x265-3.4.tar.gz"
-	cd "$PACKAGES"/x265-* || exit
+	cd "$PACKAGES"/x265-*/ || exit
 	cd source || exit
 	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off .
 	execute make -j $MJOBS


### PR DESCRIPTION
Currently the script stops with such error:

```
building x265
=======================
./build-ffmpeg: line 322: cd: too many arguments
```

