### PR TITLE
Add Travis CI testing enviroment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,39 @@
-language: c
+language: shell
 
-matrix:
+os: linux
+dist: focal
+
+jobs:
   include:
-    - os: linux
-      dist: xenial
+    - name: native build in linux
+      before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq build-essential curl ca-certificates libz-dev
+      script:
+        - while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
+        - SKIPINSTALL=yes VERBOSE=yes ./build-ffmpeg --build
+        - kill %1
+      after_script:
+        - ./build-ffmpeg --cleanup
 
-before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq build-essential curl; fi
+    - name: native build in osx
+      os: osx
+      osx_image: xcode12.2
+      script:
+        - while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
+        - SKIPINSTALL=yes VERBOSE=yes ./build-ffmpeg --build
+        - kill %1
+      after_script:
+        - ./build-ffmpeg --cleanup
 
-script:
-    - while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
-    - SKIPINSTALL=yes VERBOSE=yes ./build-ffmpeg --build
-    - kill %1
+    - name: build in docker
+      script:
+        - docker build -t ffmpeg:ubuntu -f Dockerfile .
+      after_script:
+        - docker run --rm ffmpeg:ubuntu
 
-after_script:
-    - ./build-ffmpeg --cleanup
+    - name: build in docker with cuda
+      script:
+        - docker build -t ffmpeg:cuda -f cuda-ubuntu.dockerfile .
+      after_script:
+        - docker run --rm ffmpeg:cuda

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ build-ffmpeg
 The FFmpeg build script provides an easy way to build a static FFmpeg on **OSX** and **Linux** with **non-free codecs** included.
 
 
-[![How-To build FFmpeg on MacOS](http://img.youtube.com/vi/Z9p3mM757cM/0.jpg)](http://www.youtube.com/watch?v=Z9p3mM757cM "How-To build FFmpeg on OSX")
+[![How-To build FFmpeg on MacOS](https://img.youtube.com/vi/Z9p3mM757cM/0.jpg)](https://www.youtube.com/watch?v=Z9p3mM757cM "How-To build FFmpeg on OSX")
 
 *Youtube: How-To build and install FFmpeg on MacOS*
 
 ## Disclaimer
-Use this script at your own risk. I maintain this script in my spare time. 
+Use this script at your own risk. I maintain this script in my spare time.
 Please do not file bug reports for systems other than Debian 10 and macOS 10.15.x
 because I don't have the resources and the time to maintain other systems.
 
@@ -23,7 +23,7 @@ because I don't have the resources and the time to maintain other systems.
 * `x264`: H.264 (MPEG-4 AVC)
 * `x265`: H.265 Video Codec
 * `aom`: AV1 Video Codec (Experimental and very slow!)
-* `fdk_aac`: Fraunhofer FDK AAC Codec 
+* `fdk_aac`: Fraunhofer FDK AAC Codec
 * `xvidcore`: MPEG-4 video coding standard
 * `VP8/VP9/webm`: VP8 / VP9 Video Codec for the WebM video file format
 * `mp3`: MPEG-1 or MPEG-2 Audio Layer III
@@ -45,7 +45,7 @@ because I don't have the resources and the time to maintain other systems.
         * VP9 `vp9_cuvid`
     * Encoders
         * H264 `nvenc nvenc_h264`
-        * H265 `nvenc_hevc` 
+        * H265 `nvenc_hevc`
 
 ## Continuos Integration
 ffmpeg-build-script is rockstable. Every commit runs against Linux and MacOS with https://travis-ci.org just to make sure everything works as expected.
@@ -101,11 +101,11 @@ cd ffmpeg-build-script
 ### Cuda installation
 
 CUDA is a parallel computing platform developed by NVIDIA.
-To be able to compile ffmpeg with CUDA support, you first need a compatible NVIDIA GPU. 
+To be able to compile ffmpeg with CUDA support, you first need a compatible NVIDIA GPU.
 - Ubuntu: To install the CUDA toolkit on Ubuntu, simply run "sudo apt install nvidia-cuda-toolkit"
-- Other Linux distributions: Once you have the GPU and display driver installed, you can follow the 
-[official instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) 
-or [this blog](https://www.pugetsystems.com/labs/hpc/How-To-Install-CUDA-10-1-on-Ubuntu-19-04-1405/) 
+- Other Linux distributions: Once you have the GPU and display driver installed, you can follow the
+[official instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
+or [this blog](https://www.pugetsystems.com/labs/hpc/How-To-Install-CUDA-10-1-on-Ubuntu-19-04-1405/)
 to setup the CUDA toolkit.
 
 Usage
@@ -263,7 +263,7 @@ Building done. The binary can be found here: /Volumes/Daten/dev/mac/ffmpeg-build
 Install the binary to your /usr/local/bin folder? [Y/n] y
 Password:
 ```
-    
+
 
 Other Projects Of Mine
 ------------

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -7,21 +7,23 @@ CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"
 CC=clang
-LDFLAGS="-L${WORKSPACE}/lib -lm"
-CFLAGS="-I${WORKSPACE}/include"
-ADDITIONAL_CONFIGURE_OPTIONS=""
+CFLAGS="-I$WORKSPACE/include"
+LDFLAGS="-L$WORKSPACE/lib"
+EXTRALIBS="-lpthread -lm"
+FFMPEG_OPTS=()
+CONFIGURE_OPTIONS=()
 
 # Speed up the process
 # Env Var NUMJOBS overrides automatic detection
 if [[ -n $NUMJOBS ]]; then
-    MJOBS=$NUMJOBS
+	MJOBS=$NUMJOBS
 elif [[ -f /proc/cpuinfo ]]; then
-    MJOBS=$(grep -c processor /proc/cpuinfo)
+	MJOBS=$(grep -c processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
 	MJOBS=$(sysctl -n machdep.cpu.thread_count)
-	ADDITIONAL_CONFIGURE_OPTIONS="--enable-videotoolbox"
+	CONFIGURE_OPTIONS=("--enable-videotoolbox")
 else
-    MJOBS=4
+	MJOBS=4
 fi
 
 make_dir () {
@@ -85,11 +87,11 @@ execute () {
 
 	# shellcheck disable=SC2181
 	if [ $? -ne 0 ]; then
-        echo "$OUTPUT"
-        echo ""
-        echo "Failed to Execute $*" >&2
-        exit 1
-    fi
+		echo "$OUTPUT"
+		echo ""
+		echo "Failed to Execute $*" >&2
+		exit 1
+	fi
 }
 
 build () {
@@ -106,16 +108,16 @@ build () {
 }
 
 command_exists() {
-    if ! [[ -x $(command -v "$1") ]]; then
-        return 1
-    fi
+	if ! [[ -x $(command -v "$1") ]]; then
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 
 build_done () {
-    touch "$PACKAGES/$1.done"
+	touch "$PACKAGES/$1.done"
 }
 
 echo "ffmpeg-build-script v$VERSION"
@@ -129,18 +131,18 @@ case "$1" in
 	echo "Cleanup done."
 	echo ""
 	exit 0
-    ;;
+	;;
 "--build")
 
-    ;;
+	;;
 *)
-    echo "Usage: $0"
-    echo "   --build: start building process"
-    echo "   --cleanup: remove all working dirs"
-    echo "   --help: show this help"
-    echo ""
-    exit 0
-    ;;
+	echo "Usage: $0"
+	echo "   --build: start building process"
+	echo "   --cleanup: remove all working dirs"
+	echo "   --help: show this help"
+	echo ""
+	exit 0
+	;;
 esac
 
 echo "Using $MJOBS make jobs simultaneously."
@@ -151,18 +153,18 @@ make_dir "$WORKSPACE"
 export PATH=${WORKSPACE}/bin:$PATH
 
 if ! command_exists "make"; then
-    echo "make not installed.";
-    exit 1
+	echo "make not installed.";
+	exit 1
 fi
 
 if ! command_exists "g++"; then
-    echo "g++ not installed.";
-    exit 1
+	echo "g++ not installed.";
+	exit 1
 fi
 
 if ! command_exists "curl"; then
-    echo "curl not installed.";
-    exit 1
+	echo "curl not installed.";
+	exit 1
 fi
 
 if build "yasm"; then
@@ -189,22 +191,26 @@ if build "opencore"; then
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libopencore_amrnb" "--enable-libopencore_amrwb")
 	build_done "opencore"
 fi
 
 if build "libvpx"; then
-    download "https://github.com/webmproject/libvpx/archive/v1.8.1.tar.gz" "libvpx-1.8.1.tar.gz"
-    cd "$PACKAGES"/libvpx-1.8.1 || exit
+	download "https://github.com/webmproject/libvpx/archive/v1.8.1.tar.gz" "libvpx-1.8.1.tar.gz"
+	cd "$PACKAGES"/libvpx-1.8.1 || exit
 
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo "Applying Darwin patch"
-        sed "s/,--version-script//g" build/make/Makefile > build/make/Makefile.patched
-        sed "s/-Wl,--no-undefined -Wl,-soname/-Wl,-undefined,error -Wl,-install_name/g" build/make/Makefile.patched > build/make/Makefile
-    fi
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		echo "Applying Darwin patch"
+		sed "s/,--version-script//g" build/make/Makefile > build/make/Makefile.patched
+		sed "s/-Wl,--no-undefined -Wl,-soname/-Wl,-undefined,error -Wl,-install_name/g" build/make/Makefile.patched > build/make/Makefile
+	fi
 
 	execute ./configure --prefix="${WORKSPACE}" --disable-unit-tests --disable-shared
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libvpx")
 	build_done "libvpx"
 fi
 
@@ -214,6 +220,8 @@ if build "lame"; then
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libmp3lame")
 	build_done "lame"
 fi
 
@@ -223,6 +231,8 @@ if build "opus"; then
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libopus")
 	build_done "opus"
 fi
 
@@ -235,9 +245,14 @@ if build "xvidcore"; then
 	execute make install
 
 	if [[ -f ${WORKSPACE}/lib/libxvidcore.4.dylib ]]; then
-	    execute rm "${WORKSPACE}/lib/libxvidcore.4.dylib"
+		execute rm "${WORKSPACE}/lib/libxvidcore.4.dylib"
 	fi
 
+	if [[ -f ${WORKSPACE}/lib/libxvidcore.so ]]; then
+		execute rm "${WORKSPACE}"/lib/libxvidcore.so*
+	fi
+
+	CONFIGURE_OPTIONS+=("--enable-libxvid")
 	build_done "xvidcore"
 fi
 
@@ -247,13 +262,15 @@ if build "x264"; then
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC"
-    else
-        execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
-    fi
+	else
+		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
+	fi
 
-    execute make -j $MJOBS
+	execute make -j $MJOBS
 	execute make install
 	execute make install-lib-static
+
+	CONFIGURE_OPTIONS+=("--enable-libx264")
 	build_done "x264"
 fi
 
@@ -272,6 +289,8 @@ if build "libvorbis"; then
 	execute ./configure --prefix="${WORKSPACE}" --with-ogg-libraries="${WORKSPACE}"/lib --with-ogg-includes="${WORKSPACE}"/include/ --enable-static --disable-shared --disable-oggtest
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libvorbis")
 	build_done "libvorbis"
 fi
 
@@ -284,6 +303,8 @@ if build "libtheora"; then
 	execute ./configure --prefix="${WORKSPACE}" --with-ogg-libraries="${WORKSPACE}"/lib --with-ogg-includes="${WORKSPACE}"/include/ --with-vorbis-libraries="${WORKSPACE}"/lib --with-vorbis-includes="${WORKSPACE}"/include/ --enable-static --disable-shared --disable-oggtest --disable-vorbistest --disable-examples --disable-asm --disable-spec
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libtheora")
 	build_done "libtheora"
 fi
 
@@ -314,6 +335,8 @@ if build "vid_stab"; then
 	execute cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DUSE_OMP=OFF -DENABLE_SHARED:bool=off .
 	execute make
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libvidstab")
 	build_done "vid_stab"
 fi
 
@@ -326,6 +349,8 @@ if build "x265"; then
 	execute make install
 	sed "s/-lx265/-lx265 -lstdc++/g" "$WORKSPACE/lib/pkgconfig/x265.pc" > "$WORKSPACE/lib/pkgconfig/x265.pc.tmp"
 	mv "$WORKSPACE/lib/pkgconfig/x265.pc.tmp" "$WORKSPACE/lib/pkgconfig/x265.pc"
+
+	CONFIGURE_OPTIONS+=("--enable-libx265")
 	build_done "x265"
 fi
 
@@ -335,6 +360,8 @@ if build "fdk_aac"; then
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libfdk-aac")
 	build_done "fdk_aac"
 fi
 
@@ -346,6 +373,8 @@ if build "av1"; then
 	execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" "$PACKAGES"/av1
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libaom")
 	build_done "av1"
 fi
 
@@ -364,6 +393,8 @@ if build "openssl"; then
 	execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib
 	execute make -j $MJOBS
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-openssl")
 	build_done "openssl"
 fi
 
@@ -375,61 +406,47 @@ if build "srt"; then
 	export OPENSSL_INCLUDE_DIR="${WORKSPACE}"/include/
 	execute cmake "$PACKAGES"/srt-1.4.1 -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DENABLE_APPS=OFF
 	execute make install
+
+	CONFIGURE_OPTIONS+=("--enable-libsrt")
 	build_done "srt"
 fi
 
-CFLAGS="-I$WORKSPACE/include"
-LDFLAGS="-L$WORKSPACE/lib"
 if command -v nvcc > /dev/null ; then
-       if build "nv-codec"; then
-               download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n10.0.26.0/nv-codec-headers-10.0.26.0.tar.gz" "nv-codec-headers-10.0.26.0.tar.gz"
-               cd "$PACKAGES"/nv-codec-headers-10.0.26.0 || exit
-               sed -i  "s#PREFIX = /usr/local#PREFIX = ${WORKSPACE}#g" "$PACKAGES"/nv-codec-headers-10.0.26.0/Makefile
-               execute make install
-               build_done "nv-codec"
-       fi
-       CFLAGS="$CFLAGS -I/usr/local/cuda/include"
-       LDFLAGS="$LDFLAGS -L/usr/local/cuda/lib64"
-       ADDITIONAL_CONFIGURE_OPTIONS="$ADDITIONAL_CONFIGURE_OPTIONS --enable-cuda-nvcc --enable-cuvid --enable-nvenc --enable-libnpp  --enable-cuda-llvm"
+	if build "nv-codec"; then
+		download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n10.0.26.0/nv-codec-headers-10.0.26.0.tar.gz" "nv-codec-headers-10.0.26.0.tar.gz"
+		cd "$PACKAGES"/nv-codec-headers-10.0.26.0 || exit
+		sed -i  "s#PREFIX = /usr/local#PREFIX = ${WORKSPACE}#g" "$PACKAGES"/nv-codec-headers-10.0.26.0/Makefile
+		execute make install
+		build_done "nv-codec"
+	fi
+	CFLAGS+=" -I/usr/local/cuda/include"
+	LDFLAGS+=" -L/usr/local/cuda/lib64"
+	CONFIGURE_OPTIONS+=("--enable-cuda-nvcc" "--enable-cuvid" "--enable-nvenc" "--enable-libnpp" "--enable-cuda-llvm")
+	# https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+	CONFIGURE_OPTIONS+=("--nvccflags=-gencode arch=compute_52,code=sm_52")
 fi
 
 build "ffmpeg"
 download "https://ffmpeg.org/releases/ffmpeg-4.3.1.tar.bz2" "ffmpeg-4.3.1.tar.bz2"
 cd "$PACKAGES"/ffmpeg-4.3.1/ || exit
 # shellcheck disable=SC2086
-./configure $ADDITIONAL_CONFIGURE_OPTIONS \
-    --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
-    --prefix="${WORKSPACE}" \
-    --pkg-config-flags="--static" \
-    --extra-cflags="$CFLAGS" \
-    --extra-ldflags="$LDFLAGS" \
-    --extra-libs="-lpthread -lm" \
-	--enable-static \
+./configure "${CONFIGURE_OPTIONS[@]}" \
 	--disable-debug \
-	--disable-shared \
-	--disable-ffplay \
 	--disable-doc \
-	--enable-openssl \
+	--disable-ffplay \
+	--disable-shared \
 	--enable-gpl \
-	--enable-version3 \
 	--enable-nonfree \
 	--enable-pthreads \
-	--enable-libvpx \
-	--enable-libmp3lame \
-    --enable-libopus \
-	--enable-libtheora \
-	--enable-libvorbis \
-	--enable-libx264 \
-	--enable-libx265 \
-	--enable-runtime-cpudetect \
-	--enable-libfdk-aac \
-	--enable-avfilter \
-	--enable-libopencore_amrwb \
-	--enable-libopencore_amrnb \
-	--enable-filters \
-	--enable-libvidstab \
-	--enable-libaom \
-	--enable-libsrt
+	--enable-static \
+	--enable-small \
+	--enable-version3 \
+	--extra-cflags="${CFLAGS}" \
+	--extra-ldflags="${LDFLAGS}" \
+	--extra-libs="${EXTRALIBS}" \
+	--pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
+	--pkg-config-flags="--static" \
+	--prefix="${WORKSPACE}"
 
 execute make -j $MJOBS
 execute make install

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:20.04 AS build
+FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
+
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install build-essential curl ca-certificates libz-dev \
@@ -10,7 +12,9 @@ COPY ./build-ffmpeg /app/build-ffmpeg
 
 RUN SKIPINSTALL=yes /app/build-ffmpeg --build
 
-FROM ubuntu:20.04
+FROM nvidia/cuda:11.1-runtime-ubuntu20.04
+
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
 COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe


### PR DESCRIPTION
[![Build Status](https://travis-ci.com/AkashiSN/ffmpeg-build-script.svg?branch=master)](https://travis-ci.com/AkashiSN/ffmpeg-build-script)
# Summary
- A CUDA testing environment with Docker and native OSX testing  have been added to Travis CI.
- Changed Dockerfile to use a multi-stage build.
- Added Dockerfile for building CUDA into ffmpeg with [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) container. (`cuda-ubuntu.dockerfile`)
- The indentation was unified to Tab and re-indent.
- Changed the config option (`--enable-*`) to be added in each build section (`CONFIGURE_OPTIONS`).
- Removed some config options because they were redundant.

# About CUDA
Since the version of CUDA published by [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) is 11.1 in ubuntu 20.04, and the target architecture is very old (SM30) in ffmpeg's default nvccflags and completely removed in CUDA11, the target architecture is SM52 added a flag to change to. (ref: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/)
`--nvccflags=-gencode arch=compute_52,code=sm_52`

Backwards compatibility exists (just not optimal), so you only need to change this flag when using older graphics cards or if you want to optimize for a particular graphics card.

# Removed some config options
- `--enable-runtime-cpudetect`  :  Enabled by default. (https://github.com/FFmpeg/FFmpeg/blob/6b6b9e593dd4d3aaf75f48d40a13ef03bdef9fdb/configure#L108)
- `--enable-avfilter` :  Enabled by default. (https://github.com/FFmpeg/FFmpeg/blob/6b6b9e593dd4d3aaf75f48d40a13ef03bdef9fdb/configure#L134)
- `--enable-filters` :  Enabled by default. 
(https://github.com/FFmpeg/FFmpeg/blob/6b6b9e593dd4d3aaf75f48d40a13ef03bdef9fdb/configure#L186)

# Add config options
- `--enable-libxvid` : Adding this option resulted in dynamic linking, so the code to remove the dynamic library was added.

Sincerely,