### PR TITLE
add vaapi support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,28 +52,6 @@ jobs:
         run: |
           ./build-ffmpeg --cleanup
 
-  build-macos-static:
-    name: full static build in native macOS
-    runs-on: macos-10.15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: build ffmpeg
-        run: |
-          while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
-          SKIPINSTALL=yes VERBOSE=yes ./build-ffmpeg --build --full-static
-          kill %1
-      - name: check shared library
-        run: |
-          otool -L ./workspace/bin/ffmpeg
-      - name: test run ffmepg
-        run: |
-          ./workspace/bin/ffmpeg -buildconf
-      - name: clean up
-        run: |
-          ./build-ffmpeg --cleanup
-
   build-docker:
     name: build in docker
     runs-on: ubuntu-20.04
@@ -131,12 +109,10 @@ jobs:
         id: cuda_ubuntu_centos_pull
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
-          docker pull centos:8
       - name: run if cuda_ubuntu_centos_pull failed
         if: failure() && steps.cuda_ubuntu_centos_pull.outcome == 'failure'
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
-          docker pull centos:8
       - name: build ffmpeg
         run: |
           docker build -t ffmpeg:cuda-static -f full-static.dockerfile .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,12 +86,12 @@ jobs:
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
           docker pull ubuntu:20.04
-        - name: run if cuda_ubuntu_pull failed
+      - name: run if cuda_ubuntu_pull failed
         if: failure() && steps.cuda_ubuntu_pull.outcome == 'failure'
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
           docker pull ubuntu:20.04
-        - name: build ffmpeg
+      - name: build ffmpeg
         run: |
           docker build -t ffmpeg:cuda -f cuda.dockerfile .
       - name: test run ffmepg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: install libdrm-dev
+      - name: install libva-dev
         run: |
           sudo apt-get update
-          sudo apt-get install -y libdrm-dev
+          sudo apt-get install -y libva-dev
 
       - name: build ffmpeg
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,15 +85,15 @@ jobs:
         id: cuda_ubuntu_pull
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
-          docker pull nvidia/cuda:11.1-runtime-ubuntu20.04
-      - name: run if cuda_ubuntu_pull failed
+          docker pull ubuntu:20.04
+        - name: run if cuda_ubuntu_pull failed
         if: failure() && steps.cuda_ubuntu_pull.outcome == 'failure'
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
-          docker pull nvidia/cuda:11.1-runtime-ubuntu20.04
-      - name: build ffmpeg
+          docker pull ubuntu:20.04
+        - name: build ffmpeg
         run: |
-          docker build -t ffmpeg:cuda -f cuda-ubuntu.dockerfile .
+          docker build -t ffmpeg:cuda -f cuda.dockerfile .
       - name: test run ffmepg
         run: |
           docker run --rm ffmpeg:cuda -buildconf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-linux:
-    name: native build in linux
+    name: build in native linux
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -31,7 +31,7 @@ jobs:
           ./build-ffmpeg --cleanup
 
   build-macos:
-    name: native build in macos
+    name: build in native macOS
     runs-on: macos-10.15
     steps:
       - name: Checkout code
@@ -41,6 +41,28 @@ jobs:
         run: |
           while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
           SKIPINSTALL=yes VERBOSE=yes ./build-ffmpeg --build
+          kill %1
+      - name: check shared library
+        run: |
+          otool -L ./workspace/bin/ffmpeg
+      - name: test run ffmepg
+        run: |
+          ./workspace/bin/ffmpeg -buildconf
+      - name: clean up
+        run: |
+          ./build-ffmpeg --cleanup
+
+  build-macos-static:
+    name: full static build in native macOS
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: build ffmpeg
+        run: |
+          while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
+          SKIPINSTALL=yes VERBOSE=yes ./build-ffmpeg --build --full-static
           kill %1
       - name: check shared library
         run: |
@@ -99,7 +121,7 @@ jobs:
           docker run --rm ffmpeg:cuda -buildconf
 
   build-full-static:
-    name: build full static linking in docker
+    name: build full static in docker
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           docker run --rm ffmpeg:cuda -buildconf
 
   build-full-static:
-    name: build full static in docker
+    name: full static build in docker
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
         run: |
           docker run --rm ffmpeg:ubuntu -buildconf
 
-  build-cuda-docker:
-    name: build in docker with cuda
+  build-cuda-ubuntu-docker:
+    name: build in ubuntu docker with cuda
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -93,10 +93,34 @@ jobs:
           docker pull ubuntu:20.04
       - name: build ffmpeg
         run: |
-          docker build -t ffmpeg:cuda -f cuda.dockerfile .
+          docker build -t ffmpeg:cuda-ubuntu -f cuda-ubuntu.dockerfile .
       - name: test run ffmepg
         run: |
-          docker run --rm ffmpeg:cuda -buildconf
+          docker run --rm ffmpeg:cuda-ubuntu -buildconf
+
+  build-cuda-centos-docker:
+    name: build in centos docker with cuda
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: pull base image
+        id: cuda_centos_pull
+        run: |
+          docker pull nvidia/cuda:11.1-devel-centos8
+          docker pull centos:8
+      - name: run if cuda_centos_pull failed
+        if: failure() && steps.cuda_centos_pull.outcome == 'failure'
+        run: |
+          docker pull nvidia/cuda:11.1-devel-centos8
+          docker pull centos:8
+      - name: build ffmpeg
+        run: |
+          docker build -t ffmpeg:cuda-centos -f cuda-centos.dockerfile .
+      - name: test run ffmepg
+        run: |
+          docker run --rm ffmpeg:cuda-centos -buildconf
 
   build-full-static:
     name: full static build in docker
@@ -106,11 +130,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: pull base image
-        id: cuda_ubuntu_centos_pull
+        id: cuda_ubuntu_pull
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
-      - name: run if cuda_ubuntu_centos_pull failed
-        if: failure() && steps.cuda_ubuntu_centos_pull.outcome == 'failure'
+      - name: run if cuda_ubuntu_pull failed
+        if: failure() && steps.cuda_ubuntu_pull.outcome == 'failure'
         run: |
           docker pull nvidia/cuda:11.1-devel-ubuntu20.04
       - name: build ffmpeg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: install libva-drm2
         run: |
-          apt update
-          apt install -y libva-drm2
+          sudo apt-get update
+          sudo apt-get install -y libva-drm2
 
       - name: build ffmpeg
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: install libva-drm2
+        run: |
+          apt update
+          apt install -y libva-drm2
+
       - name: build ffmpeg
         run: |
           while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: install libva-drm2
+      - name: install libdrm-dev
         run: |
           sudo apt-get update
-          sudo apt-get install -y libva-drm2
+          sudo apt-get install -y libdrm-dev
 
       - name: build ffmpeg
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:20.04
 
 # install va-driver
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install libva-drm2 \
+    && apt-get -y install libva-drm2 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:20.04 AS build
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libdrm-dev \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libva-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 AS build
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 i965-va-driver \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 
@@ -11,6 +11,11 @@ COPY ./build-ffmpeg /app/build-ffmpeg
 RUN SKIPINSTALL=yes /app/build-ffmpeg --build
 
 FROM ubuntu:20.04
+
+# install va-driver
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install libva-drm2 \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
 COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 AS build
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libz-dev \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 AS build
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 AS build
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 i965-va-driver \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libdrm-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 build-ffmpeg
 ==========
 
-The FFmpeg build script provides an easy way to build a static FFmpeg on **OSX** and **Linux** with **non-free codecs** included.
+The FFmpeg build script provides an easy way to build a static FFmpeg on **macOS** and **Linux** with **non-free codecs** included.
 
 
 [![How-To build FFmpeg on MacOS](https://img.youtube.com/vi/Z9p3mM757cM/0.jpg)](https://www.youtube.com/watch?v=Z9p3mM757cM "How-To build FFmpeg on OSX")
@@ -96,7 +96,7 @@ $ bash <(curl -s "https://raw.githubusercontent.com/markus-perl/ffmpeg-build-scr
 
 This command downloads the build script and automatically starts the build process.
 
-### Common installation
+### Common installation (macOS, Linux)
 
 ```bash
 $ git clone https://github.com/markus-perl/ffmpeg-build-script.git
@@ -104,7 +104,7 @@ $ cd ffmpeg-build-script
 $ ./build-ffmpeg --help
 ```
 
-### Build in Docker
+### Build in Docker (Linux)
 
 The main advantage of using Docker is the ability to reliably build without polluting the host environment. And you don't even have to install the CUDA SDK on your host!
 
@@ -141,17 +141,17 @@ $ ls build/lib
 libnppc.so.11 libnppicc.so.11 libnppidei.so.11 libnppig.so.11
 ```
 
-### Build in Docker (full static ver.)
+### Build in Docker (full static ver.) (Linux)
 If you're running an operating system other than the one above, a completely static build may work.
 It's easy to do, just run the following command.
 ```bash
 $ sudo -E docker build --tag=ffmpeg:cuda-static --output type=local,dest=build -f full-static.dockerfile .
 ```
 
-### Run with Docker
+### Run with Docker (macOS, Linux)
 You can also run the entire Docker if the above two fail.
 
-#### Default - Without CUDA
+#### Default - Without CUDA (macOS, Linux)
 If you don't use CUDA, it's simple and runs as follows.
 
 ```bash
@@ -159,7 +159,7 @@ $ sudo docker build --tag=ffmpeg .
 $ sudo docker run ffmpeg -i https://files.coconut.co.s3.amazonaws.com/test.mp4 -f webm -c:v libvpx -c:a libvorbis - > test.mp4
 ```
 
-#### With CUDA
+#### With CUDA (Linux)
 If you use CUDA, Docker must be higher than 19.03.
 Install the driver and `nvidia-docker2` from [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#installing-docker-ce).
 You can perform hardware acceleration by GPU by running the following.
@@ -168,7 +168,7 @@ $ sudo docker build --tag=ffmpeg:cuda -f cuda-ubuntu.dockerfile .
 $ sudo docker run --gpus all ffmpeg-cuda -hwaccel cuvid -c:v h264_cuvid -i https://files.coconut.co.s3.amazonaws.com/test.mp4 -c:v hevc_nvenc -vf scale_npp=-1:1080 - > test.mp4
 ```
 
-### Common build
+### Common build (macOS, Linux)
 
 If you want to enable CUDA, please refer to [these](#Cuda-installation) and install the SDK.
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ because I don't have the resources and the time to maintain other systems.
     * Encoders
         * H264 `nvenc_h264`
         * H265 `nvenc_hevc`
-* `amf`: [Advanced Media Framework SDK](https://gpuopen.com/advanced-media-framework/). Optimal access to AMD GPUs for multimedia processing. Supported codecs in amf:
-    * Encoders
-        * H264 `h264_amf`
-        * H265 `hevc_amf`
 * `vaapi`: [Video Acceleration API](https://trac.ffmpeg.org/wiki/Hardware/VAAPI). Installation is triggered only if libva driver installation is detected, follow [these](#Vaapi-installation) instructions for installation. Supported codecs in vaapi:
     * Encoders
         * H264 `h264_vaapi`
@@ -194,10 +190,10 @@ You will need the libva driver, so please install it below.
 
 ```bash
 # Debian and Ubuntu
-$ sudo apt install vainfo
+$ sudo apt install libva-dev vainfo
 
 # Fedora and CentOS
-$ sudo dnf install libva libva-intel-driver libva-utils
+$ sudo dnf install libva-devel libva-intel-driver libva-utils
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Requirements MacOS
 Requirements Linux
 ------------
 * Debian >= Buster, Ubuntu => Focal Fossa, other Distributions might work too
-* build-essentials installed:
+* build-essentials, curl, and Python3 is requre installed:
 
 ```
 # Debian and Ubuntu
-$ sudo apt-get install build-essential curl g++
+$ sudo apt-get install build-essential curl python3
 
 # Fedora
-$ sudo dnf install @development-tools
+$ sudo dnf install @development-tools curl python3
 ```
 
 Installation

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ ffmpeg-build-script is rockstable. Every commit runs against Linux and MacOS wit
 ### Linux
 
 * Debian >= Buster, Ubuntu => Focal Fossa, other Distributions might work too
-* build-essentials, curl, and Python3 is required installed
+* build-essentials, curl is required installed
 
 ```bash
 # Debian and Ubuntu
-$ sudo apt install build-essential curl python3
+$ sudo apt install build-essential curl
 
 # Fedora
-$ sudo dnf install @development-tools curl python3
+$ sudo dnf install @development-tools curl
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ $ sudo docker run --gpus all ffmpeg-cuda -hwaccel cuvid -c:v h264_cuvid -i https
 
 If you want to enable CUDA, please refer to [these](#Cuda-installation) and install the SDK.
 
+If you want to enable Vaapi, please refer to [these](#Vaapi-installation) and install the driver.
+
 ```bash
 $ ./build-ffmpeg --build
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ because I don't have the resources and the time to maintain other systems.
     * Encoders
         * H264 `h264_amf`
         * H265 `hevc_amf`
-* `vaapi`: [Video Acceleration API](https://trac.ffmpeg.org/wiki/Hardware/VAAPI). Supported codecs in vaapi:
+* `vaapi`: [Video Acceleration API](https://trac.ffmpeg.org/wiki/Hardware/VAAPI). Installation is triggered only if libva driver installation is detected, follow [these](#Vaapi-installation) instructions for installation. Supported codecs in vaapi:
     * Encoders
         * H264 `h264_vaapi`
         * H265 `hevc_vaapi`
@@ -78,7 +78,7 @@ ffmpeg-build-script is rockstable. Every commit runs against Linux and MacOS wit
 
 ```bash
 # Debian and Ubuntu
-$ sudo apt-get install build-essential curl python3
+$ sudo apt install build-essential curl python3
 
 # Fedora
 $ sudo dnf install @development-tools curl python3
@@ -125,7 +125,7 @@ $ export VER=8
 
 3. Start the docker build as follows.
 ```bash
-$ sudo -E docker build --tag=ffmpeg:cuda -f cuda.dockerfile --build-arg DIST=$DIST --build-arg VER=$VER .
+$ sudo -E docker build --tag=ffmpeg:cuda-$DIST -f cuda-$DIST.dockerfile --build-arg VER=$VER .
 ```
 
 4. Build an `export.dockerfile` that copies only what you need from the image you just built as follows. When running, move the library in the lib to a location where the linker can find it or set the `LD_LIBRARY_PATH`.
@@ -186,8 +186,19 @@ To be able to compile ffmpeg with CUDA support, you first need a compatible NVID
 or [this blog](https://www.pugetsystems.com/labs/hpc/How-To-Install-CUDA-10-1-on-Ubuntu-19-04-1405/)
 to setup the CUDA toolkit.
 
-Usage
-------
+## Vaapi installation
+
+You will need the libva driver, so please install it below.
+
+```bash
+# Debian and Ubuntu
+$ sudo apt install vainfo
+
+# Fedora and CentOS
+$ sudo dnf install libva libva-intel-driver libva-utils
+```
+
+## Usage
 
 ```bash
 Usage: build-ffmpeg [OPTIONS]
@@ -205,6 +216,7 @@ Options:
   See detail below: https://sourceware.org/glibc/wiki/FAQ#Even_statically_linked_programs_need_some_shared_libraries_which_is_not_acceptable_for_me.__What_can_I_do.3F
 
 - The libnpp in the CUDA SDK cannot be statically linked.
+- Vaapi cannot be statically linked.
 
 Contact
 -------

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Options:
       --version       Display version information
   -b, --build         Starts the build process
   -c, --cleanup       Remove all working dirs
-  -f, --full-static   Complete static build of ffmpeg (eg. glibc, pthreads etc...) **not recommend**
+  -f, --full-static   Complete static build of ffmpeg (eg. glibc, pthreads etc...) **only Linux**
                       Note: Because of the NSS (Name Service Switch), glibc does not recommend static links.
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Requirements MacOS
 Requirements Linux
 ------------
 * Debian >= Buster, Ubuntu => Focal Fossa, other Distributions might work too
-* build-essentials, curl, and Python3 is requre installed:
+* build-essentials, curl, and Python3 is required installed:
 
 ```
 # Debian and Ubuntu

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ sudo dnf install @development-tools curl python3
 
 ## Installation
 
-### Quick install and run
+### Quick install and run (macOS, Linux)
 
 Open your command line and run (needs curl to be installed):
 
@@ -125,7 +125,7 @@ $ export VER=8
 
 3. Start the docker build as follows.
 ```bash
-$ sudo -E docker build --tag=ffmpeg:cuda -f cuda.dockerfile --build-arg DIST=$DIST VER=$VER .
+$ sudo -E docker build --tag=ffmpeg:cuda -f cuda.dockerfile --build-arg DIST=$DIST --build-arg VER=$VER .
 ```
 
 4. Build an `export.dockerfile` that copies only what you need from the image you just built as follows. When running, move the library in the lib to a location where the linker can find it or set the `LD_LIBRARY_PATH`.

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -236,7 +236,7 @@ if build "yasm"; then
 fi
 
 if build "nasm"; then
-	download "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz"
+	download "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install
@@ -251,12 +251,27 @@ if build "pkg-config"; then
 	build_done "pkg-config"
 fi
 
+if build "zlib"; then
+	download "https://www.zlib.net/zlib-1.2.11.tar.gz"
+	execute ./configure --static  --prefix="${WORKSPACE}"
+	execute make -j $MJOBS
+	execute make install
+	build_done "zlib"
+fi
+
+if build "openssl"; then
+	download "https://www.openssl.org/source/openssl-1.1.1h.tar.gz"
+	execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "openssl"
+fi
+CONFIGURE_OPTIONS+=("--enable-openssl")
+
 if build "cmake"; then
-	download "https://cmake.org/files/v3.15/cmake-3.15.4.tar.gz"
-	rm Modules/FindJava.cmake
-	perl -p -i -e "s/get_filename_component.JNIPATH/#get_filename_component(JNIPATH/g" Tests/CMakeLists.txt
-	perl -p -i -e "s/get_filename_component.JNIPATH/#get_filename_component(JNIPATH/g" Tests/CMakeLists.txt
-	execute ./configure --prefix="${WORKSPACE}"
+	download "https://cmake.org/files/v3.18/cmake-3.18.4.tar.gz"
+	execute ./configure --prefix="${WORKSPACE}" --system-zlib
 	execute make -j $MJOBS
 	execute make install
 	build_done "cmake"
@@ -286,11 +301,15 @@ CONFIGURE_OPTIONS+=("--enable-libx264")
 
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/Release_3.5.tar.gz" "x265-3.5.tar.gz"
-	cd source || exit
-	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON -DENABLE_CLI:BOOL=OFF .
+	cd build/linux || exit
+	execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DSTATIC_LINK_CRT=ON ../../source
 	execute make -j $MJOBS
 	execute make install
-	sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "$WORKSPACE/lib/pkgconfig/x265.pc" #The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+
+	if [ -n $LDEXEFLAGS ]; then
+		sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "${WORKSPACE}/lib/pkgconfig/x265.pc" # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+	fi
+
 	build_done "x265"
 fi
 CONFIGURE_OPTIONS+=("--enable-libx265")
@@ -435,24 +454,6 @@ CONFIGURE_OPTIONS+=("--enable-libfdk-aac")
 ## other library
 ##
 
-if build "zlib"; then
-	download "https://www.zlib.net/zlib-1.2.11.tar.gz"
-	execute ./configure --static --prefix="${WORKSPACE}"
-	execute make -j $MJOBS
-	execute make install
-	build_done "zlib"
-fi
-
-if build "openssl"; then
-	download "https://www.openssl.org/source/openssl-1.1.1h.tar.gz"
-	execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib
-	execute make -j $MJOBS
-	execute make install
-
-	build_done "openssl"
-fi
-CONFIGURE_OPTIONS+=("--enable-openssl")
-
 if build "srt"; then
 	download "https://github.com/Haivision/srt/archive/v1.4.1.tar.gz" "srt-1.4.1.tar.gz"
 	export OPENSSL_ROOT_DIR="${WORKSPACE}"
@@ -460,11 +461,15 @@ if build "srt"; then
 	export OPENSSL_INCLUDE_DIR="${WORKSPACE}"/include/
 	execute cmake . -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DENABLE_APPS=OFF -DUSE_STATIC_LIBSTDCXX=ON
 	execute make install
-	sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "$WORKSPACE/lib/pkgconfig/srt.pc" #The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+
+	if [ -n $LDEXEFLAGS ]; then
+		sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "$WORKSPACE/lib/pkgconfig/srt.pc" # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+	fi
 
 	build_done "srt"
 fi
 CONFIGURE_OPTIONS+=("--enable-libsrt")
+
 
 ##
 ## HWaccel library
@@ -472,9 +477,9 @@ CONFIGURE_OPTIONS+=("--enable-libsrt")
 
 if command -v nvcc > /dev/null ; then
 	if build "nv-codec"; then
-		download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n10.0.26.0/nv-codec-headers-10.0.26.0.tar.gz"
-		sed -i.backup "s#PREFIX = /usr/local#PREFIX = ${WORKSPACE}#g" Makefile #The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
-		execute make install
+		download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.0.10.0/nv-codec-headers-11.0.10.0.tar.gz"
+		execute make PREFIX="${WORKSPACE}"
+		execute make install PREFIX="${WORKSPACE}"
 		build_done "nv-codec"
 	fi
 	CFLAGS+=" -I/usr/local/cuda/include"
@@ -482,12 +487,20 @@ if command -v nvcc > /dev/null ; then
 	CONFIGURE_OPTIONS+=("--enable-cuda-nvcc" "--enable-cuvid" "--enable-nvenc" "--enable-cuda-llvm")
 
 	if [ -z $LDEXEFLAGS ]; then
-		CONFIGURE_OPTIONS+=("--enable-libnpp") # Only libnpp cannot be static link.
+		CONFIGURE_OPTIONS+=("--enable-libnpp") # Only libnpp cannot be statically linked.
 	fi
 
 	# https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
 	CONFIGURE_OPTIONS+=("--nvccflags=-gencode arch=compute_52,code=sm_52")
 fi
+
+if build "amf"; then
+	download "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/1.4.16.1.tar.gz" "amf-1.4.16.1.tar.gz"
+	execute mkdir -p ${WORKSPACE}/include/AMF
+	execute cp -r amf/public/include/* ${WORKSPACE}/include/AMF/
+	build_done "amf"
+fi
+CONFIGURE_OPTIONS+=("--enable-amf")
 
 
 ##

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -175,9 +175,6 @@ while (( $# > 0 )); do
 			fi
 			if [[ "$1" == "--full-static" || "$1" =~ 'f' ]]; then
 				LDEXEFLAGS="-static"
-				if [[ "$OSTYPE" == "darwin"* ]]; then
-					LDEXEFLAGS="-Bstatic"
-				fi
 			fi
 			shift
 			;;

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -10,7 +10,7 @@ WORKSPACE="$CWD/workspace"
 CFLAGS="-I$WORKSPACE/include"
 LDFLAGS="-L$WORKSPACE/lib"
 LDEXEFLAGS=""
-EXTRALIBS="-ldl -lpthread -lm -lz"
+EXTRALIBS="-Wl,-Bdynamic,-lc,-ldl,-lpthread,-lm,-Bstatic,-lz,-lbz2,-llzma"
 CONFIGURE_OPTIONS=()
 
 # Speed up the process
@@ -175,6 +175,9 @@ while (( $# > 0 )); do
 			fi
 			if [[ "$1" == "--full-static" || "$1" =~ 'f' ]]; then
 				LDEXEFLAGS="-static"
+				if [[ "$OSTYPE" == "darwin"* ]]; then
+					LDEXEFLAGS="-Bstatic"
+				fi
 			fi
 			shift
 			;;
@@ -370,16 +373,12 @@ CONFIGURE_OPTIONS+=("--enable-libx264")
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/Release_3.5.tar.gz" "x265-3.5.tar.gz"
 	cd build/linux || exit
+	execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF ../../source
+	execute make -j $MJOBS
+	execute make install
 
 	if [ -n "$LDEXEFLAGS" ]; then
-		execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK_CRT=ON ../../source
-		execute make -j $MJOBS
-		execute make install
 		sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "${WORKSPACE}/lib/pkgconfig/x265.pc" # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
-	else
-		execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF ../../source
-		execute make -j $MJOBS
-		execute make install
 	fi
 
 	build_done "x265"

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -220,6 +220,7 @@ mkdir -p "$PACKAGES"
 mkdir -p "$WORKSPACE"
 
 export PATH="${WORKSPACE}/bin:$PATH"
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
 
 if ! command_exists "make"; then
 	echo "make not installed.";
@@ -338,7 +339,7 @@ if build "libvpx"; then
 		sed "s/-Wl,--no-undefined -Wl,-soname/-Wl,-undefined,error -Wl,-install_name/g" build/make/Makefile.patched > build/make/Makefile
 	fi
 
-	execute ./configure --prefix="${WORKSPACE}" --disable-unit-tests --disable-shared
+	execute ./configure --prefix="${WORKSPACE}" --disable-unit-tests --disable-shared --as=yasm
 	execute make -j $MJOBS
 	execute make install
 
@@ -367,7 +368,7 @@ CONFIGURE_OPTIONS+=("--enable-libxvid")
 
 if build "vid_stab"; then
 	download "https://github.com/georgmartius/vid.stab/archive/v1.1.0.tar.gz" "vid.stab-1.1.0.tar.gz"
-	execute cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DUSE_OMP=OFF -DENABLE_SHARED:bool=off .
+	execute cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DUSE_OMP=OFF -DENABLE_SHARED=off .
 	execute make
 	execute make install
 
@@ -380,7 +381,7 @@ if build "av1"; then
 	download "https://aomedia.googlesource.com/aom/+archive/430d58446e1f71ec2283af0d6c1879bc7a3553dd.tar.gz" "av1.tar.gz" "av1"
 	make_dir "$PACKAGES"/aom_build
 	cd "$PACKAGES"/aom_build || exit
-	execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" "$PACKAGES"/av1
+	execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib "$PACKAGES"/av1
 	execute make -j $MJOBS
 	execute make install
 
@@ -474,7 +475,7 @@ if build "srt"; then
 	export OPENSSL_ROOT_DIR="${WORKSPACE}"
 	export OPENSSL_LIB_DIR="${WORKSPACE}"/lib
 	export OPENSSL_INCLUDE_DIR="${WORKSPACE}"/include/
-	execute cmake . -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DENABLE_APPS=OFF -DUSE_STATIC_LIBSTDCXX=ON
+	execute cmake . -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_INCLUDEDIR=include -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DENABLE_APPS=OFF -DUSE_STATIC_LIBSTDCXX=ON
 	execute make install
 
 	if [ -n "$LDEXEFLAGS" ]; then
@@ -512,7 +513,11 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 
 	# Vaapi doesn't work well with static links ffmpeg.
 	if [ -z "$LDEXEFLAGS" ]; then
+		# If the libva development SDK is installed, enable vaapi.
 		if library_exists "libva" ; then
+			if build "vaapi"; then
+				build_done "vaapi"
+			fi
 			CONFIGURE_OPTIONS+=("--enable-vaapi")
 		fi
 	fi

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -302,7 +302,7 @@ CONFIGURE_OPTIONS+=("--enable-libx264")
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/Release_3.5.tar.gz" "x265-3.5.tar.gz"
 	cd source || exit
-	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON -DENABLE_CLI:BOOL=OFF .
+	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON .
 	execute make -j $MJOBS
 	execute make install
 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -292,8 +292,7 @@ if build "yasm"; then
 fi
 
 if build "nasm"; then
-	download "https://github.com/netwide-assembler/nasm/archive/nasm-2.15.05.tar.gz"
-	execute ./autogen.sh
+	download "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -239,7 +239,7 @@ fi
 ##
 
 if build "m4"; then
-	download "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.xz"
+	download "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
 	# https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
 	# No new version of M4 has been released, so a patch has been applied.
 	execute curl -sLJO https://github.com/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
@@ -251,7 +251,7 @@ if build "m4"; then
 fi
 
 if build "autoconf"; then
-	download "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.xz"
+	download "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz"
 	execute ./configure --prefix="${WORKSPACE}"
 	execute make -j $MJOBS
 	execute make install
@@ -259,7 +259,7 @@ if build "autoconf"; then
 fi
 
 if build "automake"; then
-	download "https://ftpmirror.gnu.org/automake/automake-1.16.tar.xz"
+	download "https://ftp.gnu.org/gnu/automake/automake-1.16.tar.xz"
 	execute ./configure --prefix="${WORKSPACE}"
 	execute make -j $MJOBS
 	execute make install
@@ -267,7 +267,7 @@ if build "automake"; then
 fi
 
 if build "libtool"; then
-	download "https://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.xz"
+	download "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz"
 	execute ./configure --prefix="${WORKSPACE}"  --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -301,8 +301,8 @@ CONFIGURE_OPTIONS+=("--enable-libx264")
 
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/Release_3.5.tar.gz" "x265-3.5.tar.gz"
-	cd build/linux || exit
-	execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DSTATIC_LINK_CRT=ON ../../source
+	cd source || exit
+	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON -DENABLE_CLI:BOOL=OFF .
 	execute make -j $MJOBS
 	execute make install
 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -220,7 +220,9 @@ mkdir -p "$PACKAGES"
 mkdir -p "$WORKSPACE"
 
 export PATH="${WORKSPACE}/bin:$PATH"
-export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
+PKG_CONFIG_PATH="/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig"
+PKG_CONFIG_PATH+=":/usr/local/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib64/pkgconfig"
+export PKG_CONFIG_PATH
 
 if ! command_exists "make"; then
 	echo "make not installed.";

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -238,8 +238,53 @@ fi
 ## build tools
 ##
 
+if build "m4"; then
+	download "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.xz"
+	# https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
+	# No new version of M4 has been released, so a patch has been applied.
+	execute curl -sLJO https://github.com/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
+	execute patch -p1 -d . < M4-1.4.18_glibc_2.28.patch
+	execute ./configure --prefix="${WORKSPACE}"
+	execute make -j $MJOBS
+	execute make install
+	build_done "m4"
+fi
+
+if build "autoconf"; then
+	download "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.xz"
+	execute ./configure --prefix="${WORKSPACE}"
+	execute make -j $MJOBS
+	execute make install
+	build_done "autoconf"
+fi
+
+if build "automake"; then
+	download "https://ftpmirror.gnu.org/automake/automake-1.16.tar.xz"
+	execute ./configure --prefix="${WORKSPACE}"
+	execute make -j $MJOBS
+	execute make install
+	build_done "automake"
+fi
+
+if build "libtool"; then
+	download "https://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.xz"
+	execute ./configure --prefix="${WORKSPACE}"  --disable-shared --enable-static
+	execute make -j $MJOBS
+	execute make install
+	build_done "libtool"
+fi
+
+if build "util-macros"; then
+	download "https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.2/macros-util-macros-1.19.2.tar.bz2" "util-macros-1.19.2.tar.bz2"
+	execute autoreconf --force --verbose --install
+	execute ./configure --prefix="${WORKSPACE}"
+	execute make -j $MJOBS
+	execute make install
+	build_done "util-macros"
+fi
+
 if build "yasm"; then
-	download "https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz"
+	download "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz"
 	execute ./configure --prefix="${WORKSPACE}"
 	execute make -j $MJOBS
 	execute make install
@@ -247,7 +292,8 @@ if build "yasm"; then
 fi
 
 if build "nasm"; then
-	download "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz"
+	download "https://github.com/netwide-assembler/nasm/archive/nasm-2.15.05.tar.gz"
+	execute ./autogen.sh
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install
@@ -255,7 +301,8 @@ if build "nasm"; then
 fi
 
 if build "pkg-config"; then
-	download "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
+	download "https://gitlab.freedesktop.org/pkg-config/pkg-config/-/archive/pkg-config-0.29.2/pkg-config-pkg-config-0.29.2.tar.bz2" "pkg-config-0.29.2.tar.bz2"
+	execute autoreconf --force --verbose --install
 	execute ./configure --silent --prefix="${WORKSPACE}" --with-pc-path="${WORKSPACE}"/lib/pkgconfig --with-internal-glib
 	execute make -j $MJOBS
 	execute make install
@@ -290,50 +337,6 @@ fi
 
 # Required for building vaapi tools so linux only
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	if build "m4"; then
-		download "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.xz"
-		# https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
-		# No new version of M4 has been released, so a patch has been applied.
-		execute curl -sLJO https://github.com/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
-		execute patch -p1 -d . < M4-1.4.18_glibc_2.28.patch
-		execute ./configure --prefix="${WORKSPACE}"
-		execute make -j $MJOBS
-		execute make install
-		build_done "m4"
-	fi
-
-	if build "autoconf"; then
-		download "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.xz"
-		execute ./configure --prefix="${WORKSPACE}"
-		execute make -j $MJOBS
-		execute make install
-		build_done "autoconf"
-	fi
-
-	if build "automake"; then
-		download "https://ftpmirror.gnu.org/automake/automake-1.16.tar.xz"
-		execute ./configure --prefix="${WORKSPACE}"
-		execute make -j $MJOBS
-		execute make install
-		build_done "automake"
-	fi
-
-	if build "util-macros"; then
-		download "https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.2/macros-util-macros-1.19.2.tar.bz2" "util-macros-1.19.2.tar.bz2"
-		execute ./configure --prefix="${WORKSPACE}"
-		execute make -j $MJOBS
-		execute make install
-		build_done "util-macros"
-	fi
-
-	if build "libtool"; then
-		download "https://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.xz"
-		execute ./configure --prefix="${WORKSPACE}"  --disable-shared --enable-static
-		execute make -j $MJOBS
-		execute make install
-		build_done "libtool"
-	fi
-
 	if build "meson"; then
 		download "https://github.com/mesonbuild/meson/releases/download/0.55.3/meson-0.55.3.tar.gz"
 		execute ln -s $(pwd)/meson.py ${WORKSPACE}/bin/meson

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -10,7 +10,7 @@ WORKSPACE="$CWD/workspace"
 CFLAGS="-I$WORKSPACE/include"
 LDFLAGS="-L$WORKSPACE/lib"
 LDEXEFLAGS=""
-EXTRALIBS="-Wl,-Bdynamic,-lc,-ldl,-lpthread,-lm,-Bstatic,-lz,-lbz2,-llzma"
+EXTRALIBS="-ldl -lpthread -lm -lz"
 CONFIGURE_OPTIONS=()
 
 # Speed up the process

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -2,7 +2,7 @@
 
 # https://github.com/markus-perl/ffmpeg-build-script
 
-PROGNAME=$(basename $0)
+PROGNAME=$(basename "$0")
 VERSION=1.18
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
@@ -10,13 +10,13 @@ WORKSPACE="$CWD/workspace"
 CFLAGS="-I$WORKSPACE/include"
 LDFLAGS="-L$WORKSPACE/lib"
 LDEXEFLAGS=""
-EXTRALIBS="-lpthread -lm -lz"
+EXTRALIBS="-ldl -lpthread -lm -lz"
 CONFIGURE_OPTIONS=()
 
 # Speed up the process
 # Env Var NUMJOBS overrides automatic detection
-if [[ -n $NUMJOBS ]]; then
-	MJOBS=$NUMJOBS
+if [[ -n "$NUMJOBS" ]]; then
+	MJOBS="$NUMJOBS"
 elif [[ -f /proc/cpuinfo ]]; then
 	MJOBS=$(grep -c processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -44,17 +44,17 @@ download () {
 	# download url [filename[dirname]]
 
 	DOWNLOAD_PATH="$PACKAGES"
-	DOWNLOAD_FILE=${2:-"${1##*/}"}
+	DOWNLOAD_FILE="${2:-"${1##*/}"}"
 
 	if [[ "$DOWNLOAD_FILE" =~ "tar." ]]; then
 		TARGETDIR="${DOWNLOAD_FILE%.*}"
-		TARGETDIR=${3:-"${TARGETDIR%.*}"}
+		TARGETDIR="${3:-"${TARGETDIR%.*}"}"
 	else
-		TARGETDIR=${3:-"${DOWNLOAD_FILE%.*}"}
+		TARGETDIR="${3:-"${DOWNLOAD_FILE%.*}"}"
 	fi
 
 	if [ ! -f "$DOWNLOAD_PATH/$DOWNLOAD_FILE" ]; then
-		echo "Downloading $1"
+		echo "Downloading $1 as $DOWNLOAD_FILE"
 		curl -L --silent -o "$DOWNLOAD_PATH/$DOWNLOAD_FILE" "$1"
 
 		EXITCODE=$?
@@ -162,7 +162,7 @@ while (( $# > 0 )); do
 			exit 0
 			;;
 		--version)
-			echo $VERSION
+			echo "$VERSION"
 			exit 0
 			;;
 		-*)
@@ -185,8 +185,8 @@ while (( $# > 0 )); do
 	esac
 done
 
-if [ -z $bflag ]; then
-	if [ -z $cflag ]; then
+if [ -z "$bflag" ]; then
+	if [ -z "$cflag" ]; then
 		usage
 		exit 1
 	fi
@@ -199,7 +199,7 @@ echo ""
 
 echo "Using $MJOBS make jobs simultaneously."
 
-if [ -n $LDEXEFLAGS ]; then
+if [ -n "$LDEXEFLAGS" ]; then
 	echo "Start the build in full static mode."
 fi
 
@@ -221,6 +221,13 @@ fi
 if ! command_exists "curl"; then
 	echo "curl not installed.";
 	exit 1
+fi
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if ! command_exists "python3" ; then
+		echo "python3 not installed.";
+		exit 1
+	fi
 fi
 
 ##
@@ -277,6 +284,67 @@ if build "cmake"; then
 	build_done "cmake"
 fi
 
+# Required for building vaapi tools so linux only
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if build "m4"; then
+		download "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
+		# https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
+		# No new version of M4 has been released, so a patch has been applied.
+		execute curl -sLJO https://github.com/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
+		execute patch -p1 -d . < M4-1.4.18_glibc_2.28.patch
+		execute ./configure --prefix="${WORKSPACE}"
+		execute make -j $MJOBS
+		execute make install
+		build_done "m4"
+	fi
+
+	if build "autoconf"; then
+		download "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz"
+		execute ./configure --prefix="${WORKSPACE}"
+		execute make -j $MJOBS
+		execute make install
+		build_done "autoconf"
+	fi
+
+	if build "automake"; then
+		download "https://ftp.gnu.org/gnu/automake/automake-1.16.tar.xz"
+		execute ./configure --prefix="${WORKSPACE}"
+		execute make -j $MJOBS
+		execute make install
+		build_done "automake"
+	fi
+
+	if build "util-macros"; then
+		download "https://www.x.org/archive/individual/util/util-macros-1.19.2.tar.gz"
+		execute ./configure --prefix="${WORKSPACE}"
+		execute make -j $MJOBS
+		execute make install
+		build_done "util-macros"
+	fi
+
+	if build "libtool"; then
+		download "https://ftp.jaist.ac.jp/pub/GNU/libtool/libtool-2.4.6.tar.xz"
+		execute ./configure --prefix="${WORKSPACE}"  --disable-shared --enable-static
+		execute make -j $MJOBS
+		execute make install
+		build_done "libtool"
+	fi
+
+	if build "meson"; then
+		download "https://github.com/mesonbuild/meson/releases/download/0.55.3/meson-0.55.3.tar.gz"
+		execute ln -s $(pwd)/meson.py ${WORKSPACE}/bin/meson
+		build_done "meson"
+	fi
+
+	if build "ninja"; then
+		download "https://github.com/ninja-build/ninja/archive/v1.10.1.tar.gz" "ninja-1.10.1.tar.gz"
+		execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" .
+		execute make -j $MJOBS
+		execute make install
+		build_done "ninja"
+	fi
+fi
+
 
 ##
 ## video library
@@ -301,13 +369,17 @@ CONFIGURE_OPTIONS+=("--enable-libx264")
 
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/Release_3.5.tar.gz" "x265-3.5.tar.gz"
-	cd source || exit
-	execute cmake -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED:bool=off -DSTATIC_LINK_CRT:BOOL=ON .
-	execute make -j $MJOBS
-	execute make install
+	cd build/linux || exit
 
-	if [ -n $LDEXEFLAGS ]; then
+	if [ -n "$LDEXEFLAGS" ]; then
+		execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK_CRT=ON ../../source
+		execute make -j $MJOBS
+		execute make install
 		sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "${WORKSPACE}/lib/pkgconfig/x265.pc" # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+	else
+		execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF ../../source
+		execute make -j $MJOBS
+		execute make install
 	fi
 
 	build_done "x265"
@@ -462,8 +534,8 @@ if build "srt"; then
 	execute cmake . -DCMAKE_INSTALL_PREFIX:PATH="${WORKSPACE}" -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DENABLE_APPS=OFF -DUSE_STATIC_LIBSTDCXX=ON
 	execute make install
 
-	if [ -n $LDEXEFLAGS ]; then
-		sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "$WORKSPACE/lib/pkgconfig/srt.pc" # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+	if [ -n "$LDEXEFLAGS" ]; then
+		sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "${WORKSPACE}"/lib/pkgconfig/srt.pc # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
 	fi
 
 	build_done "srt"
@@ -475,34 +547,69 @@ CONFIGURE_OPTIONS+=("--enable-libsrt")
 ## HWaccel library
 ##
 
-if command -v nvcc > /dev/null ; then
-	if build "nv-codec"; then
-		download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.0.10.0/nv-codec-headers-11.0.10.0.tar.gz"
-		execute make PREFIX="${WORKSPACE}"
-		execute make install PREFIX="${WORKSPACE}"
-		build_done "nv-codec"
-	fi
-	CFLAGS+=" -I/usr/local/cuda/include"
-	LDFLAGS+=" -L/usr/local/cuda/lib64"
-	CONFIGURE_OPTIONS+=("--enable-cuda-nvcc" "--enable-cuvid" "--enable-nvenc" "--enable-cuda-llvm")
-
-	if [ -z $LDEXEFLAGS ]; then
-		CONFIGURE_OPTIONS+=("--enable-libnpp") # Only libnpp cannot be statically linked.
-	fi
-
-	# https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
-	CONFIGURE_OPTIONS+=("--nvccflags=-gencode arch=compute_52,code=sm_52")
-fi
-
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if command_exists nvcc ; then
+		if build "nv-codec"; then
+			download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.0.10.0/nv-codec-headers-11.0.10.0.tar.gz"
+			execute make PREFIX="${WORKSPACE}"
+			execute make install PREFIX="${WORKSPACE}"
+			build_done "nv-codec"
+		fi
+		CFLAGS+=" -I/usr/local/cuda/include"
+		LDFLAGS+=" -L/usr/local/cuda/lib64"
+		CONFIGURE_OPTIONS+=("--enable-cuda-nvcc" "--enable-cuvid" "--enable-nvenc" "--enable-cuda-llvm")
+
+		if [ -z "$LDEXEFLAGS" ]; then
+			CONFIGURE_OPTIONS+=("--enable-libnpp") # Only libnpp cannot be statically linked.
+		fi
+
+		# https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+		CONFIGURE_OPTIONS+=("--nvccflags=-gencode arch=compute_52,code=sm_52")
+	fi
+
 	if build "amf"; then
 		download "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/1.4.16.1.tar.gz" "amf-1.4.16.1.tar.gz"
-		execute mkdir -p ${WORKSPACE}/include/AMF
-		execute cp -r amf/public/include/* ${WORKSPACE}/include/AMF/
+		execute mkdir -p "${WORKSPACE}"/include/AMF
+		execute cp -r amf/public/include/* "${WORKSPACE}"/include/AMF/
 		build_done "amf"
 	fi
 	CONFIGURE_OPTIONS+=("--enable-amf")
+
+	if build "libpciaccess"; then
+		download "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.bz2" "libpciaccess-0.16.tar.bz2"
+		execute autoreconf --force --verbose --install
+		execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static CFLAGS=-fPIC
+		execute make -j $MJOBS
+		execute make install
+		build_done "libpciaccess"
+	fi
+
+	if build "libdrm"; then
+		download "https://dri.freedesktop.org/libdrm/libdrm-2.4.102.tar.xz"
+		execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib builddir/
+		execute ninja -C builddir/ install
+		build_done "libdrm"
+	fi
+
+	if build "libva"; then
+		download "https://github.com/intel/libva/releases/download/2.9.0/libva-2.9.0.tar.bz2"
+		execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+		execute make -j $MJOBS
+		execute make install
+		build_done "libva"
+	fi
+
+	if build "intel-vaapi-driver"; then
+		download "https://github.com/intel/intel-vaapi-driver/releases/download/2.4.1/intel-vaapi-driver-2.4.1.tar.bz2"
+		execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+		execute make -j $MJOBS
+		execute make install
+		build_done "intel-vaapi-driver"
+	fi
+
+	CONFIGURE_OPTIONS+=("--enable-vaapi")
 fi
+
 
 ##
 ## FFmpeg
@@ -542,7 +649,7 @@ echo ""
 echo "Building done. The binary can be found here: $WORKSPACE/bin/ffmpeg"
 echo ""
 
-if [[ $AUTOINSTALL == "yes" ]]; then
+if [[ "$AUTOINSTALL" == "yes" ]]; then
 	if command_exists "sudo"; then
 		sudo cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
 		sudo cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
@@ -552,7 +659,7 @@ if [[ $AUTOINSTALL == "yes" ]]; then
 		cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
 		echo "Done. ffmpeg is now installed to your system."
 	fi
-elif [[ ! $SKIPINSTALL == "yes" ]]; then
+elif [[ ! "$SKIPINSTALL" == "yes" ]]; then
 	read -r -p "Install the binary to your $INSTALL_FOLDER folder? [Y/n] " response
 	case $response in
 	[yY][eE][sS]|[yY])

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -287,7 +287,7 @@ fi
 # Required for building vaapi tools so linux only
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	if build "m4"; then
-		download "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
+		download "https://ftpmirror.gnu.org/m4/m4-1.4.18.tar.xz"
 		# https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
 		# No new version of M4 has been released, so a patch has been applied.
 		execute curl -sLJO https://github.com/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
@@ -299,7 +299,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	fi
 
 	if build "autoconf"; then
-		download "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz"
+		download "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.xz"
 		execute ./configure --prefix="${WORKSPACE}"
 		execute make -j $MJOBS
 		execute make install
@@ -307,7 +307,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	fi
 
 	if build "automake"; then
-		download "https://ftp.gnu.org/gnu/automake/automake-1.16.tar.xz"
+		download "https://ftpmirror.gnu.org/automake/automake-1.16.tar.xz"
 		execute ./configure --prefix="${WORKSPACE}"
 		execute make -j $MJOBS
 		execute make install
@@ -315,7 +315,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	fi
 
 	if build "util-macros"; then
-		download "https://www.x.org/archive/individual/util/util-macros-1.19.2.tar.gz"
+		download "https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.2/macros-util-macros-1.19.2.tar.bz2" "util-macros-1.19.2.tar.bz2"
 		execute ./configure --prefix="${WORKSPACE}"
 		execute make -j $MJOBS
 		execute make install
@@ -323,7 +323,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	fi
 
 	if build "libtool"; then
-		download "https://ftp.jaist.ac.jp/pub/GNU/libtool/libtool-2.4.6.tar.xz"
+		download "https://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.xz"
 		execute ./configure --prefix="${WORKSPACE}"  --disable-shared --enable-static
 		execute make -j $MJOBS
 		execute make install
@@ -581,7 +581,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	fi
 
 	if build "libdrm"; then
-		download "https://dri.freedesktop.org/libdrm/libdrm-2.4.102.tar.xz"
+		download "https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-2.4.102/drm-libdrm-2.4.102.tar.bz2" "libdrm-2.4.102.tar.bz2"
 		execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib builddir/
 		execute ninja -C builddir/ install
 		build_done "libdrm"

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -590,11 +590,11 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 
 	# Vaapi doesn't work well with static links ffmpeg.
 	if [ -z "$LDEXEFLAGS" ]; then
-		if library_exists "libdrm" ; then
+		if library_exists "libva" ; then
 			if build "libpciaccess"; then
 				download "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.bz2" "libpciaccess-0.16.tar.bz2"
 				execute autoreconf --force --verbose --install
-				execute ./configure --prefix="${WORKSPACE}" --disable-static --enable-shared CFLAGS=-fPIC
+				execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static CFLAGS=-fPIC
 				execute make -j $MJOBS
 				execute make install
 				build_done "libpciaccess"
@@ -616,14 +616,6 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 				execute make -j $MJOBS
 				execute make install
 				build_done "libva"
-			fi
-
-			if build "intel-vaapi-driver"; then
-				download "https://github.com/intel/intel-vaapi-driver/releases/download/2.4.1/intel-vaapi-driver-2.4.1.tar.bz2"
-				execute ./configure --prefix="${WORKSPACE}" --disable-static --enable-shared
-				execute make -j $MJOBS
-				execute make install
-				build_done "intel-vaapi-driver"
 			fi
 			CONFIGURE_OPTIONS+=("--enable-vaapi")
 		fi

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -260,7 +260,6 @@ fi
 
 if build "pkg-config"; then
 	download "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
-	execute autoreconf --force --verbose --install
 	execute ./configure --silent --prefix="${WORKSPACE}" --with-pc-path="${WORKSPACE}"/lib/pkgconfig --with-internal-glib
 	execute make -j $MJOBS
 	execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -3,7 +3,7 @@
 # https://github.com/markus-perl/ffmpeg-build-script
 
 PROGNAME=$(basename "$0")
-VERSION=1.18
+VERSION=1.19
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"
@@ -150,7 +150,7 @@ usage () {
 	echo "      --version       Display version information"
 	echo "  -b, --build         Starts the build process"
 	echo "  -c, --cleanup       Remove all working dirs"
-	echo "  -f, --full-static   Complete static build of ffmpeg (eg. glibc, pthreads etc...) **not recommend**"
+	echo "  -f, --full-static   Complete static build of ffmpeg (eg. glibc, pthreads etc...) **only Linux**"
 	echo "                      Note: Because of the NSS (Name Service Switch), glibc does not recommend static links."
 	echo ""
 }
@@ -174,6 +174,10 @@ while (( $# > 0 )); do
 				cleanup
 			fi
 			if [[ "$1" == "--full-static" || "$1" =~ 'f' ]]; then
+				if [[ "$OSTYPE" == "darwin"* ]]; then
+					echo "Error: full-static mode is available only Linux."
+					exit 1
+				fi
 				LDEXEFLAGS="-static"
 			fi
 			shift

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -494,14 +494,15 @@ if command -v nvcc > /dev/null ; then
 	CONFIGURE_OPTIONS+=("--nvccflags=-gencode arch=compute_52,code=sm_52")
 fi
 
-if build "amf"; then
-	download "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/1.4.16.1.tar.gz" "amf-1.4.16.1.tar.gz"
-	execute mkdir -p ${WORKSPACE}/include/AMF
-	execute cp -r amf/public/include/* ${WORKSPACE}/include/AMF/
-	build_done "amf"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if build "amf"; then
+		download "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/1.4.16.1.tar.gz" "amf-1.4.16.1.tar.gz"
+		execute mkdir -p ${WORKSPACE}/include/AMF
+		execute cp -r amf/public/include/* ${WORKSPACE}/include/AMF/
+		build_done "amf"
+	fi
+	CONFIGURE_OPTIONS+=("--enable-amf")
 fi
-CONFIGURE_OPTIONS+=("--enable-amf")
-
 
 ##
 ## FFmpeg

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -123,7 +123,7 @@ build () {
 	return 0
 }
 
-command_exists() {
+command_exists () {
 	if ! [[ -x $(command -v "$1") ]]; then
 		return 1
 	fi
@@ -131,6 +131,17 @@ command_exists() {
 	return 0
 }
 
+library_exists () {
+	if ! command_exists "ldconfig"; then
+		return 1
+	fi
+
+	if ! [ -n "$(ldconfig -p | grep "$1")" ]; then
+		return 1
+	fi
+
+	return 0
+}
 
 build_done () {
 	touch "$PACKAGES/$1.done"
@@ -550,7 +561,7 @@ CONFIGURE_OPTIONS+=("--enable-libsrt")
 ##
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	if command_exists nvcc ; then
+	if command_exists "nvcc" ; then
 		if build "nv-codec"; then
 			download "https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.0.10.0/nv-codec-headers-11.0.10.0.tar.gz"
 			execute make PREFIX="${WORKSPACE}"
@@ -577,39 +588,46 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	fi
 	CONFIGURE_OPTIONS+=("--enable-amf")
 
-	if build "libpciaccess"; then
-		download "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.bz2" "libpciaccess-0.16.tar.bz2"
-		execute autoreconf --force --verbose --install
-		execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static CFLAGS=-fPIC
-		execute make -j $MJOBS
-		execute make install
-		build_done "libpciaccess"
-	fi
+	# Vaapi doesn't work well with static links ffmpeg.
+	if [ -z "$LDEXEFLAGS" ]; then
+		if library_exists "libdrm" ; then
+			if build "libpciaccess"; then
+				download "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.bz2" "libpciaccess-0.16.tar.bz2"
+				execute autoreconf --force --verbose --install
+				execute ./configure --prefix="${WORKSPACE}" --disable-static --enable-shared CFLAGS=-fPIC
+				execute make -j $MJOBS
+				execute make install
+				build_done "libpciaccess"
+			fi
 
-	if build "libdrm"; then
-		download "https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-2.4.102/drm-libdrm-2.4.102.tar.bz2" "libdrm-2.4.102.tar.bz2"
-		execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib builddir/
-		execute ninja -C builddir/ install
-		build_done "libdrm"
-	fi
+			# https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/28
+			# Since libdrm should not be statically linked, neither should libva or intel-vaapi-driver, on which it depends, be statically linked.
+			# They should be installed as drivers in your host OS.
+			if build "libdrm"; then
+				download "https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-2.4.102/drm-libdrm-2.4.102.tar.bz2" "libdrm-2.4.102.tar.bz2"
+				execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib builddir/
+				execute ninja -C builddir/ install
+				build_done "libdrm"
+			fi
 
-	if build "libva"; then
-		download "https://github.com/intel/libva/releases/download/2.9.0/libva-2.9.0.tar.bz2"
-		execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
-		execute make -j $MJOBS
-		execute make install
-		build_done "libva"
-	fi
+			if build "libva"; then
+				download "https://github.com/intel/libva/releases/download/2.9.0/libva-2.9.0.tar.bz2"
+				execute ./configure --prefix="${WORKSPACE}" --disable-static --enable-shared
+				execute make -j $MJOBS
+				execute make install
+				build_done "libva"
+			fi
 
-	if build "intel-vaapi-driver"; then
-		download "https://github.com/intel/intel-vaapi-driver/releases/download/2.4.1/intel-vaapi-driver-2.4.1.tar.bz2"
-		execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
-		execute make -j $MJOBS
-		execute make install
-		build_done "intel-vaapi-driver"
+			if build "intel-vaapi-driver"; then
+				download "https://github.com/intel/intel-vaapi-driver/releases/download/2.4.1/intel-vaapi-driver-2.4.1.tar.bz2"
+				execute ./configure --prefix="${WORKSPACE}" --disable-static --enable-shared
+				execute make -j $MJOBS
+				execute make install
+				build_done "intel-vaapi-driver"
+			fi
+			CONFIGURE_OPTIONS+=("--enable-vaapi")
+		fi
 	fi
-
-	CONFIGURE_OPTIONS+=("--enable-vaapi")
 fi
 
 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -132,11 +132,9 @@ command_exists () {
 }
 
 library_exists () {
-	if ! command_exists "ldconfig"; then
-		return 1
-	fi
-
-	if ! [ -n "$(ldconfig -p | grep "$1")" ]; then
+	local result=0
+	local output=$(pkg-config --exists --print-errors "$1" 2>&1 > /dev/null) || result=$?
+	if [ ! "$result" = "0" ]; then
 		return 1
 	fi
 
@@ -238,61 +236,10 @@ if ! command_exists "curl"; then
 	exit 1
 fi
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	if ! command_exists "python3" ; then
-		echo "python3 not installed.";
-		exit 1
-	fi
-fi
 
 ##
 ## build tools
 ##
-
-if build "m4"; then
-	download "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.xz"
-	# https://lists.gnu.org/archive/html/bug-m4/2018-08/msg00000.html
-	# No new version of M4 has been released, so a patch has been applied.
-	execute curl -sLJO https://github.com/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/m/M4/M4-1.4.18_glibc_2.28.patch
-	execute patch -p1 -d . < M4-1.4.18_glibc_2.28.patch
-	execute ./configure --prefix="${WORKSPACE}"
-	execute make -j $MJOBS
-	execute make install
-	build_done "m4"
-fi
-
-if build "autoconf"; then
-	download "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz"
-	execute ./configure --prefix="${WORKSPACE}"
-	execute make -j $MJOBS
-	execute make install
-	build_done "autoconf"
-fi
-
-if build "automake"; then
-	download "https://ftp.gnu.org/gnu/automake/automake-1.16.tar.xz"
-	execute ./configure --prefix="${WORKSPACE}"
-	execute make -j $MJOBS
-	execute make install
-	build_done "automake"
-fi
-
-if build "libtool"; then
-	download "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz"
-	execute ./configure --prefix="${WORKSPACE}"  --disable-shared --enable-static
-	execute make -j $MJOBS
-	execute make install
-	build_done "libtool"
-fi
-
-if build "util-macros"; then
-	download "https://gitlab.freedesktop.org/xorg/util/macros/-/archive/util-macros-1.19.2/macros-util-macros-1.19.2.tar.bz2" "util-macros-1.19.2.tar.bz2"
-	execute autoreconf --force --verbose --install
-	execute ./configure --prefix="${WORKSPACE}"
-	execute make -j $MJOBS
-	execute make install
-	build_done "util-macros"
-fi
 
 if build "yasm"; then
 	download "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz"
@@ -311,7 +258,7 @@ if build "nasm"; then
 fi
 
 if build "pkg-config"; then
-	download "https://gitlab.freedesktop.org/pkg-config/pkg-config/-/archive/pkg-config-0.29.2/pkg-config-pkg-config-0.29.2.tar.bz2" "pkg-config-0.29.2.tar.bz2"
+	download "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
 	execute autoreconf --force --verbose --install
 	execute ./configure --silent --prefix="${WORKSPACE}" --with-pc-path="${WORKSPACE}"/lib/pkgconfig --with-internal-glib
 	execute make -j $MJOBS
@@ -343,23 +290,6 @@ if build "cmake"; then
 	execute make -j $MJOBS
 	execute make install
 	build_done "cmake"
-fi
-
-# Required for building vaapi tools so linux only
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	if build "meson"; then
-		download "https://github.com/mesonbuild/meson/releases/download/0.55.3/meson-0.55.3.tar.gz"
-		execute ln -s $(pwd)/meson.py ${WORKSPACE}/bin/meson
-		build_done "meson"
-	fi
-
-	if build "ninja"; then
-		download "https://github.com/ninja-build/ninja/archive/v1.10.1.tar.gz" "ninja-1.10.1.tar.gz"
-		execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" .
-		execute make -j $MJOBS
-		execute make install
-		build_done "ninja"
-	fi
 fi
 
 
@@ -580,43 +510,9 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		CONFIGURE_OPTIONS+=("--nvccflags=-gencode arch=compute_52,code=sm_52")
 	fi
 
-	if build "amf"; then
-		download "https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/1.4.16.1.tar.gz" "amf-1.4.16.1.tar.gz"
-		execute mkdir -p "${WORKSPACE}"/include/AMF
-		execute cp -r amf/public/include/* "${WORKSPACE}"/include/AMF/
-		build_done "amf"
-	fi
-	CONFIGURE_OPTIONS+=("--enable-amf")
-
 	# Vaapi doesn't work well with static links ffmpeg.
 	if [ -z "$LDEXEFLAGS" ]; then
 		if library_exists "libva" ; then
-			if build "libpciaccess"; then
-				download "https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/archive/libpciaccess-0.16/libpciaccess-libpciaccess-0.16.tar.bz2" "libpciaccess-0.16.tar.bz2"
-				execute autoreconf --force --verbose --install
-				execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static CFLAGS=-fPIC
-				execute make -j $MJOBS
-				execute make install
-				build_done "libpciaccess"
-			fi
-
-			# https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/28
-			# Since libdrm should not be statically linked, neither should libva or intel-vaapi-driver, on which it depends, be statically linked.
-			# They should be installed as drivers in your host OS.
-			if build "libdrm"; then
-				download "https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-2.4.102/drm-libdrm-2.4.102.tar.bz2" "libdrm-2.4.102.tar.bz2"
-				execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}"/lib builddir/
-				execute ninja -C builddir/ install
-				build_done "libdrm"
-			fi
-
-			if build "libva"; then
-				download "https://github.com/intel/libva/releases/download/2.9.0/libva-2.9.0.tar.bz2"
-				execute ./configure --prefix="${WORKSPACE}" --disable-static --enable-shared
-				execute make -j $MJOBS
-				execute make install
-				build_done "libva"
-			fi
 			CONFIGURE_OPTIONS+=("--enable-vaapi")
 		fi
 	fi

--- a/cuda-centos.dockerfile
+++ b/cuda-centos.dockerfile
@@ -4,8 +4,8 @@ FROM nvidia/cuda:11.1-devel-centos${VER} AS build
 
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
-RUN yum groupinstall -y "Development Tools" \
-    && yum install -y kernel-devel kernel-headers curl python3 vaapi-driver-i965 \
+RUN yum group install -y "Development Tools" \
+    && yum install -y curl python3 libva \
     && rm -rf /var/cache/yum/* \
     && yum clean all
 

--- a/cuda-centos.dockerfile
+++ b/cuda-centos.dockerfile
@@ -1,0 +1,39 @@
+ARG VER=8
+
+FROM nvidia/cuda:11.1-devel-centos${VER} AS build
+
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+
+RUN yum groupinstall -y "Development Tools" \
+    && yum install -y kernel-devel kernel-headers curl python3 vaapi-driver-i965 \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all
+
+WORKDIR /app
+COPY ./build-ffmpeg /app/build-ffmpeg
+
+RUN SKIPINSTALL=yes /app/build-ffmpeg --build
+
+
+FROM centos:${VER}
+
+# install va-driver
+RUN yum install -y libva \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all
+
+# Copy libnpp
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppc.so.11 /lib/x86_64-linux-gnu/libnppc.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppig.so.11 /lib/x86_64-linux-gnu/libnppig.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppicc.so.11 /lib/x86_64-linux-gnu/libnppicc.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppidei.so.11 /lib/x86_64-linux-gnu/libnppidei.so.11
+
+# Copy ffmpeg
+COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
+COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe
+
+RUN ldd /usr/bin/ffmpeg ; exit 0
+RUN ldd /usr/bin/ffprobe ; exit 0
+
+CMD         ["--help"]
+ENTRYPOINT  ["/usr/bin/ffmpeg"]

--- a/cuda-centos.dockerfile
+++ b/cuda-centos.dockerfile
@@ -5,7 +5,7 @@ FROM nvidia/cuda:11.1-devel-centos${VER} AS build
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN yum group install -y "Development Tools" \
-    && yum install -y curl python3 libva \
+    && yum install -y curl libva-devel \
     && rm -rf /var/cache/yum/* \
     && yum clean all
 

--- a/cuda-centos.dockerfile
+++ b/cuda-centos.dockerfile
@@ -23,10 +23,10 @@ RUN yum install -y libva \
     && yum clean all
 
 # Copy libnpp
-COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppc.so.11 /lib/x86_64-linux-gnu/libnppc.so.11
-COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppig.so.11 /lib/x86_64-linux-gnu/libnppig.so.11
-COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppicc.so.11 /lib/x86_64-linux-gnu/libnppicc.so.11
-COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppidei.so.11 /lib/x86_64-linux-gnu/libnppidei.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppc.so.11 /lib64/libnppc.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppig.so.11 /lib64/libnppig.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppicc.so.11 /lib64/libnppicc.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppidei.so.11 /lib64/libnppidei.so.11
 
 # Copy ffmpeg
 COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libz-dev \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -20,7 +20,7 @@ FROM ubuntu:${VER}
 
 # install va-driver
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install libva-drm2 \
+    && apt-get -y install libva-drm2 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Copy libnpp

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -2,10 +2,11 @@ ARG VER=20.04
 
 FROM nvidia/cuda:11.1-devel-ubuntu${VER} AS build
 
+ENV DEBIAN_FRONTEND noninteractive
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 libva-drm2 \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libdrm-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -1,12 +1,11 @@
-ARG DIST=ubuntu
 ARG VER=20.04
 
-FROM nvidia/cuda:11.1-devel-${DIST}${VER} AS build
+FROM nvidia/cuda:11.1-devel-ubuntu${VER} AS build
 
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 i965-va-driver \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 
@@ -16,7 +15,12 @@ COPY ./build-ffmpeg /app/build-ffmpeg
 RUN SKIPINSTALL=yes /app/build-ffmpeg --build
 
 
-FROM ${DIST}:${VER}
+FROM ubuntu:${VER}
+
+# install va-driver
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install libva-drm2 \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Copy libnpp
 COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppc.so.11 /lib/x86_64-linux-gnu/libnppc.so.11

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -5,7 +5,7 @@ FROM nvidia/cuda:11.1-devel-ubuntu${VER} AS build
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 i965-va-driver \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 libva-drm2 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libdrm-dev \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libva-dev \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/cuda.dockerfile
+++ b/cuda.dockerfile
@@ -1,4 +1,7 @@
-FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
+ARG DIST=ubuntu
+ARG VER=20.04
+
+FROM nvidia/cuda:11.1-devel-${DIST}${VER} AS build
 
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
@@ -12,10 +15,16 @@ COPY ./build-ffmpeg /app/build-ffmpeg
 
 RUN SKIPINSTALL=yes /app/build-ffmpeg --build
 
-FROM nvidia/cuda:11.1-runtime-ubuntu20.04
 
-ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
+FROM ${DIST}:${VER}
 
+# Copy libnpp
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppc.so.11 /lib/x86_64-linux-gnu/libnppc.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppig.so.11 /lib/x86_64-linux-gnu/libnppig.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppicc.so.11 /lib/x86_64-linux-gnu/libnppicc.so.11
+COPY --from=build /usr/local/cuda-11.1/targets/x86_64-linux/lib/libnppidei.so.11 /lib/x86_64-linux-gnu/libnppidei.so.11
+
+# Copy ffmpeg
 COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
 COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe
 

--- a/export.dockerfile
+++ b/export.dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+# Copy libnpp
+COPY --from=ffmpeg:cuda /lib/x86_64-linux-gnu/libnppc.so.11 /lib/libnppc.so.11
+COPY --from=ffmpeg:cuda /lib/x86_64-linux-gnu/libnppig.so.11 /lib/libnppig.so.11
+COPY --from=ffmpeg:cuda /lib/x86_64-linux-gnu/libnppicc.so.11 /lib/libnppicc.so.11
+COPY --from=ffmpeg:cuda /lib/x86_64-linux-gnu/libnppidei.so.11 /lib/libnppidei.so.11
+
+# Copy ffmpeg
+COPY --from=ffmpeg:cuda /usr/bin/ffmpeg /bin/ffmpeg
+COPY --from=ffmpeg:cuda /usr/bin/ffprobe /bin/ffprobe

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates libz-dev \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -10,15 +10,14 @@ RUN apt-get update \
 WORKDIR /app
 COPY ./build-ffmpeg /app/build-ffmpeg
 
-RUN SKIPINSTALL=yes /app/build-ffmpeg --build --full-static
+RUN AUTOINSTALL=yes /app/build-ffmpeg --build --full-static
+RUN ldd /app/workspace/bin/ffmpeg ; exit 0
+RUN ldd /app/workspace/bin/ffprobe ; exit 0
 
-FROM centos:8
+FROM scratch
 
 COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
 COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe
-
-RUN ldd /usr/bin/ffmpeg ; exit 0
-RUN ldd /usr/bin/ffprobe ; exit 0
 
 CMD         ["--help"]
 ENTRYPOINT  ["/usr/bin/ffmpeg"]

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -1,9 +1,10 @@
 FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
 
+ENV DEBIAN_FRONTEND noninteractive
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:11.1-devel-ubuntu20.04 AS build
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -11,13 +11,14 @@ WORKDIR /app
 COPY ./build-ffmpeg /app/build-ffmpeg
 
 RUN AUTOINSTALL=yes /app/build-ffmpeg --build --full-static
+
 RUN ldd /app/workspace/bin/ffmpeg ; exit 0
 RUN ldd /app/workspace/bin/ffprobe ; exit 0
 
 FROM scratch
 
-COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
-COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe
+COPY --from=build /app/workspace/bin/ffmpeg /ffmpeg
+COPY --from=build /app/workspace/bin/ffprobe /ffprobe
 
 CMD         ["--help"]
-ENTRYPOINT  ["/usr/bin/ffmpeg"]
+ENTRYPOINT  ["/ffmpeg"]


### PR DESCRIPTION
![build test](https://github.com/AkashiSN/ffmpeg-build-script/workflows/build%20test/badge.svg?branch=vaapi)

- add AMF support
- add vaapi support
- With the addition of vaapi support, Python3 is now required for Linux.
- Downloading failed on some sources, so we changed the download destination to GitHub or GitLab.
- I added autotools because I needed them for that.

Best regards.