### PR TITLE
The cli check for cleanup always matches when --full-static is passed

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -179,7 +179,7 @@ while (( $# > 0 )); do
 			if [[ "$1" == "--build" || "$1" =~ 'b' ]]; then
 				bflag='-b'
 			fi
-			if [[ "$1" == "--cleanup" || "$1" =~ 'c' ]]; then
+			if [[ "$1" == "--cleanup" || "$1" =~ 'c'  && ! "$1" =~ '--' ]]; then
 				cflag='-c'
 				cleanup
 			fi


### PR DESCRIPTION
There is an ambiguity in how short and long cli flags are passed that causes the script to clean whenever a full-static build is attempted with long cli option `--full-static`.

The second clause of the conditional that checks for the cleanup flag

```bash
    if [[ "$1" == "--cleanup" || "$1" =~ 'c' ]]; then
```

is overly broad and evaluates as truthy if $1 is "--full-cleanup". This
can be easily fixed by appending an additional string check along the lines of `|| "$1" =~ 'c'  && ! "$1" =~ '--'`.