### PR TITLE
Random patches and tricks for building on M1

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -160,7 +160,7 @@ verify_binary_type () {
 	echo ""
 	case $BINARY_TYPE in
 		"Mach-O 64-bit executable arm64")
-			echo "Successfully built Apple Silicon (M1): ${BINARY_TYPE}"
+			echo "Successfully built Apple Silicon (M1) for ${OSTYPE}: ${BINARY_TYPE}"
 			;;
 		*)
 			echo "Successfully built binary for ${OSTYPE}: ${BINARY_TYPE}"

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -12,12 +12,14 @@ CFLAGS='-I$WORKSPACE/include'
 LDFLAGS="-L$WORKSPACE/lib"
 LDEXEFLAGS=""
 EXTRALIBS="-ldl -lpthread -lm -lz"
+MACOS_M1=false
 CONFIGURE_OPTIONS=()
 # Check for Apple Silicon 
 if [[ ( "$(uname -m)" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
   # If arm64 AND darwin (macOS)
   export ARCH=arm64
   export MACOSX_DEPLOYMENT_TARGET=11.0
+  MACOS_M1=true
 fi
 
 
@@ -151,6 +153,19 @@ library_exists () {
 
 build_done () {
 	touch "$PACKAGES/$1.done"
+}
+
+verify_binary_type () {
+	BINARY_TYPE=$(file $WORKSPACE/bin/ffmpeg | sed -n 's/^.*\:\ \(.*$\)/\1/p')
+	echo ""
+	case $BINARY_TYPE in
+		"Mach-O 64-bit executable arm64")
+			echo "Successfully built Apple Silicon (M1): ${BINARY_TYPE}"
+			;;
+		*)
+			echo "Successfully built binary for ${OSTYPE}: ${BINARY_TYPE}"
+			;;
+	esac
 }
 
 cleanup () {
@@ -358,9 +373,9 @@ fi
 
 if build "openssl"; then
 	download "https://www.openssl.org/source/openssl-1.1.1i.tar.gz"
-	if [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+	if $MACOS_M1 ; then 
 		sed -n 's/\(##### GNU Hurd\)/"darwin64-arm64-cc" => { \n    inherit_from     => [ "darwin-common", asm("aarch64_asm") ],\n    CFLAGS           => add("-Wall"),\n    cflags           => add("-arch arm64 "),\n    lib_cppflags     => add("-DL_ENDIAN"),\n    bn_ops           => "SIXTY_FOUR_BIT_LONG", \n    perlasm_scheme   => "macosx", \n}, \n\1/g' Configurations/10-main.conf
-   		execute ./Configure --prefix="${WORKSPACE}" no-shared no-asm darwin64-arm64-cc 
+   		execute ./configure --prefix="${WORKSPACE}" no-shared no-asm darwin64-arm64-cc 
 	else
 		execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib 
 	fi
@@ -388,13 +403,14 @@ if build "x264"; then
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC"
-	elif [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+	elif $MACOS_M1 ; then
 		## Get latest code to support arm64
-		git clone --depth 1 -b master https://code.videolan.org/videolan/x264.git
-		cd x264
-	else 
+		download "https://code.videolan.org/videolan/x264/-/archive/0d754ec36013fee82978496cd56fbd48824910b3/x264-0d754ec36013fee82978496cd56fbd48824910b3.tar.gz" "x264-0d754ec.tar.gz"
+		cd "${PACKAGES}"/x264-0d754ec
+	else
 		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
 	fi
+	
 
 	execute make -j $MJOBS
 	execute make install
@@ -458,9 +474,10 @@ CONFIGURE_OPTIONS+=("--enable-libxvid")
 
 if build "vid_stab"; then
 	download "https://github.com/georgmartius/vid.stab/archive/v1.1.0.tar.gz" "vid.stab-1.1.0.tar.gz"
-	## rich
-	if [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
-		curl -s -o "$PACKAGES/vid.stab-1.1.0/fix_cmake_quoting.patch" https://raw.githubusercontent.com/Homebrew/formula-patches/5bf1a0e0cfe666ee410305cece9c9c755641bfdf/libvidstab/fix_cmake_quoting.patch
+
+	if $MACOS_M1 ; then 
+
+	curl -s -o "$PACKAGES/vid.stab-1.1.0/fix_cmake_quoting.patch" https://raw.githubusercontent.com/Homebrew/formula-patches/5bf1a0e0cfe666ee410305cece9c9c755641bfdf/libvidstab/fix_cmake_quoting.patch
 		patch -p1 < fix_cmake_quoting.patch
 	fi
 	## rich
@@ -476,13 +493,11 @@ if build "av1"; then
 	download "https://aomedia.googlesource.com/aom/+archive/b52ee6d44adaef8a08f6984390de050d64df9faa.tar.gz" "av1.tar.gz" "av1"
 	make_dir "$PACKAGES"/aom_build
 	cd "$PACKAGES"/aom_build || exit
-	## rich
-	if [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+	if $MACOS_M1 ; then 
 		execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib -DCONFIG_RUNTIME_CPU_DETECT=0 "$PACKAGES"/av1 
 	else
 		execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib "$PACKAGES"/av1 
 	fi
-	## rich (added runtime detect )
 	execute make -j $MJOBS
 	execute make install
 
@@ -680,8 +695,10 @@ execute make install
 
 INSTALL_FOLDER="/usr/bin"
 if [[ "$OSTYPE" == "darwin"* ]]; then
-INSTALL_FOLDER="/usr/local/bin"
+	INSTALL_FOLDER="/usr/local/bin"
 fi
+
+verify_binary_type
 
 echo ""
 echo "Building done. The following binaries can be found here:"
@@ -710,11 +727,11 @@ elif [[ ! "$SKIPINSTALL" == "yes" ]]; then
 		if command_exists "sudo"; then
 			sudo cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
 			sudo cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
-      sudo cp "$WORKSPACE/bin/ffplay" "$INSTALL_FOLDER/ffplay"
+      		sudo cp "$WORKSPACE/bin/ffplay" "$INSTALL_FOLDER/ffplay"
 		else
 			cp "$WORKSPACE/bin/ffmpeg" "$INSTALL_FOLDER/ffmpeg"
 			cp "$WORKSPACE/bin/ffprobe" "$INSTALL_FOLDER/ffprobe"
-      cp "$WORKSPACE/bin/ffplay" "$INSTALL_FOLDER/ffplay"
+     		 cp "$WORKSPACE/bin/ffplay" "$INSTALL_FOLDER/ffplay"
 		fi
 		echo "Done. FFmpeg is now installed to your system."
 		;;

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -8,11 +8,18 @@ VERSION=1.21
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"
-CFLAGS="-I$WORKSPACE/include"
+CFLAGS='-I$WORKSPACE/include'
 LDFLAGS="-L$WORKSPACE/lib"
 LDEXEFLAGS=""
 EXTRALIBS="-ldl -lpthread -lm -lz"
 CONFIGURE_OPTIONS=()
+# Check for Apple Silicon 
+if [[ ( "$(uname -m)" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+  # If arm64 AND darwin (macOS)
+  export ARCH=arm64
+  export MACOSX_DEPLOYMENT_TARGET=11.0
+fi
+
 
 # Speed up the process
 # Env Var NUMJOBS overrides automatic detection
@@ -350,11 +357,15 @@ if build "zlib"; then
 fi
 
 if build "openssl"; then
-	download "https://www.openssl.org/source/openssl-1.1.1h.tar.gz"
-	execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib
+	download "https://www.openssl.org/source/openssl-1.1.1i.tar.gz"
+	if [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+		sed -n 's/\(##### GNU Hurd\)/"darwin64-arm64-cc" => { \n    inherit_from     => [ "darwin-common", asm("aarch64_asm") ],\n    CFLAGS           => add("-Wall"),\n    cflags           => add("-arch arm64 "),\n    lib_cppflags     => add("-DL_ENDIAN"),\n    bn_ops           => "SIXTY_FOUR_BIT_LONG", \n    perlasm_scheme   => "macosx", \n}, \n\1/g' Configurations/10-main.conf
+   		execute ./Configure --prefix="${WORKSPACE}" no-shared no-asm darwin64-arm64-cc 
+	else
+		execute ./config --prefix="${WORKSPACE}" --openssldir="${WORKSPACE}" --with-zlib-include="${WORKSPACE}"/include/ --with-zlib-lib="${WORKSPACE}"/lib no-shared zlib 
+	fi
 	execute make -j $MJOBS
 	execute make install_sw
-
 	build_done "openssl"
 fi
 CONFIGURE_OPTIONS+=("--enable-openssl")
@@ -377,7 +388,11 @@ if build "x264"; then
 
 	if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC"
-	else
+	elif [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+		## Get latest code to support arm64
+		git clone --depth 1 -b master https://code.videolan.org/videolan/x264.git
+		cd x264
+	else 
 		execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
 	fi
 
@@ -392,6 +407,7 @@ CONFIGURE_OPTIONS+=("--enable-libx264")
 if build "x265"; then
 	download "https://github.com/videolan/x265/archive/Release_3.5.tar.gz" "x265-3.5.tar.gz"
 	cd build/linux || exit
+
 	execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF ../../source
 	execute make -j $MJOBS
 	execute make install
@@ -442,6 +458,12 @@ CONFIGURE_OPTIONS+=("--enable-libxvid")
 
 if build "vid_stab"; then
 	download "https://github.com/georgmartius/vid.stab/archive/v1.1.0.tar.gz" "vid.stab-1.1.0.tar.gz"
+	## rich
+	if [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+		curl -s -o "$PACKAGES/vid.stab-1.1.0/fix_cmake_quoting.patch" https://raw.githubusercontent.com/Homebrew/formula-patches/5bf1a0e0cfe666ee410305cece9c9c755641bfdf/libvidstab/fix_cmake_quoting.patch
+		patch -p1 < fix_cmake_quoting.patch
+	fi
+	## rich
 	execute cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DUSE_OMP=OFF -DENABLE_SHARED=off .
 	execute make
 	execute make install
@@ -454,7 +476,13 @@ if build "av1"; then
 	download "https://aomedia.googlesource.com/aom/+archive/b52ee6d44adaef8a08f6984390de050d64df9faa.tar.gz" "av1.tar.gz" "av1"
 	make_dir "$PACKAGES"/aom_build
 	cd "$PACKAGES"/aom_build || exit
-	execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib "$PACKAGES"/av1
+	## rich
+	if [[ ( "$ARCH" == "arm64" ) && ( "$OSTYPE" == "darwin"* ) ]]; then 
+		execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib -DCONFIG_RUNTIME_CPU_DETECT=0 "$PACKAGES"/av1 
+	else
+		execute cmake -DENABLE_TESTS=0 -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib "$PACKAGES"/av1 
+	fi
+	## rich (added runtime detect )
 	execute make -j $MJOBS
 	execute make install
 
@@ -560,7 +588,7 @@ CONFIGURE_OPTIONS+=("--enable-libwebp")
 ##
 
 if build "libsdl"; then
-	download "https://www.libsdl.org/release/SDL2-2.0.12.tar.gz"
+	download "https://www.libsdl.org/release/SDL2-2.0.14.tar.gz"
 	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
 	execute make -j $MJOBS
 	execute make install


### PR DESCRIPTION
*Preview only* 
I suspect several things in here are questionable, open to ideas/better ways. But it builds! (On Big Sur, on my machine, etc...)

*Notes* 
* Needs newer code repo's in some cases, and some conditionals to check platform. (or just intake the new code versions)
* The external patches possibly should be brought in? Seems to work for now if anyone is in need. 
* xvidcore failed to build once but it seemed to be a timing thing with file existence...re-running worked

Learnings from https://github.com/ssut/ffmpeg-on-apple-silicon

*Output analysis* 
```
file /usr/local/bin/ffmpeg
/usr/local/bin/ffmpeg: Mach-O 64-bit executable arm64
```

```
otool -L /usr/local/bin/ffmpeg
/usr/local/bin/ffmpeg:
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1770.255.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
	/System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation (compatibility version 1.0.0, current version 2.0.0)
	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (compatibility version 1.2.0, current version 1.5.0)
	/System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1463.2.1)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
	/System/Library/Frameworks/CoreHaptics.framework/Versions/A/CoreHaptics (compatibility version 1.0.0, current version 1.0.0, weak)
	/System/Library/Frameworks/GameController.framework/Versions/A/GameController (compatibility version 1.0.0, current version 1.0.0, weak)
	/System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback (compatibility version 1.0.0, current version 1.0.2)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 164.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore (compatibility version 1.2.0, current version 1.11.0, weak)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 244.32.7, weak)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreImage.framework/Versions/A/CoreImage (compatibility version 1.0.1, current version 5.0.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2022.20.117)
	/usr/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.5)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 904.4.0)
	/System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1770.255.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1122.11.0)
```