### PR TITLE
build-ffmpeg: ffmpeg source and cmake minor version update

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -699,7 +699,7 @@ fi
 ##
 
 build "ffmpeg"
-download "https://www.ffmpeg.org/releases/ffmpeg-4.4.tar.gz"
+download "https://github.com/FFmpeg/FFmpeg/archive/refs/heads/release/4.4.tar.gz" "FFmpeg-release-4.4.tar.gz"
 # shellcheck disable=SC2086
 ./configure "${CONFIGURE_OPTIONS[@]}" \
   --disable-debug \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -402,7 +402,7 @@ if $NONFREE_AND_GPL; then
 fi
 
 if build "cmake"; then
-  download "https://cmake.org/files/LatestRelease/cmake-3.20.2.tar.gz"
+  download "https://cmake.org/files/LatestRelease/cmake-3.21.0.tar.gz"
   execute ./configure --prefix="${WORKSPACE}" --parallel="${MJOBS}" -- -DCMAKE_USE_OPENSSL=OFF
   execute make -j $MJOBS
   execute make install


### PR DESCRIPTION
- The previous script was breaking in the middle of compilation without this patch. Now the script will download cmake source from proper path.
- Version number fetching could be made autonomous if `jq` could be used in all build platforms (IDK if they are prebuilt in the systems) as cmake keeps note of the latest version in a JSON file in the Release Directory.