### PR TITLE
Corrects path for newer version of sctav1

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -440,7 +440,7 @@ if ! $MACOS_M1; then
   if build "svtav1" "0.9.0"; then
     # Last known working commit which passed CI Tests from HEAD branch
     download "https://github.com/AOMediaCodec/SVT-AV1/archive/refs/tags/v0.9.0.tar.gz" "svtav1-0.9.0.tar.gz"
-    cd "${PACKAGES}"/SVT-AV1-0.9.0/Build/linux || exit
+    cd "${PACKAGES}"/svtav1-0.9.0/Build/linux || exit
     execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF ../.. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
     execute make -j $MJOBS
     execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -440,7 +440,7 @@ if ! $MACOS_M1; then
   if build "svtav1" "0.9.0"; then
     # Last known working commit which passed CI Tests from HEAD branch
     download "https://github.com/AOMediaCodec/SVT-AV1/archive/refs/tags/v0.9.0.tar.gz" "svtav1-0.9.0.tar.gz"
-    cd "${PACKAGES}"/svtav1-1a3e32b/Build/linux || exit
+    cd "${PACKAGES}"/SVT-AV1-0.9.0/Build/linux || exit
     execute cmake -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DENABLE_SHARED=off -DBUILD_SHARED_LIBS=OFF ../.. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
     execute make -j $MJOBS
     execute make install


### PR DESCRIPTION
Commit [e7c88f5](https://github.com/markus-perl/ffmpeg-build-script/commit/e7c88f5647e87bccfb31c3067f75470c8e9e4327) introduced issue where path was no longer valid.