### PR TITLE
Updating config.guess file. Which allowed me to compile on aarch64 (A…

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -743,6 +743,11 @@ if build "libtheora" "1.1.1"; then
   sed "s/-fforce-addr//g" configure >configure.patched
   chmod +x configure.patched
   mv configure.patched configure
+  ##BEGIN CONFIG.GUESS PATCH -- Updating config.guess file. Which allowed me to compile on aarch64 (ARMv8) [linux kernel 4.9 Ubuntu 20.04]
+  rm config.guess
+  wget --quiet -O config.guess - https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess
+  chmod +x config.guess
+  ##END OF CONFIG.GUESS PATCH
   execute ./configure --prefix="${WORKSPACE}" --with-ogg-libraries="${WORKSPACE}"/lib --with-ogg-includes="${WORKSPACE}"/include/ --with-vorbis-libraries="${WORKSPACE}"/lib --with-vorbis-includes="${WORKSPACE}"/include/ --enable-static --disable-shared --disable-oggtest --disable-vorbistest --disable-examples --disable-asm --disable-spec
   execute make -j $MJOBS
   execute make install


### PR DESCRIPTION
Updating config.guess file. Which allowed me to compile on aarch64 (ARMv8) [linux kernel 4.9 Ubuntu 20.04]

When compiling libtheora during the vanilla gpl and only FREE encoders/decoders -- an error was thrown from the GNU GCC 'config.guess' file, which simply stated that my OS ENV couldn't be guessed.  That same error message printed out the year that the 'config.guess' was last updated, and suggested that I look for a newer file.

Same discussion and solution was proposed here:
https://gitlab.xiph.org/xiph/theora/-/issues/1595

I then found a new config.guess file from a gcc-mirror, and put in a 3-line patch on my system, and it worked without an issue.

I thought that maybe this patch could prevent others from running into this problem.