### PR TITLE
Pass through CXXFLAGS from parent environment

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -481,7 +481,7 @@ if $NONFREE_AND_GPL; then
     cd "${PACKAGES}"/x264-5db6aa6 || exit
 
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
-      execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC"
+      execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic CXXFLAGS="-fPIC ${CXXFLAGS}"
     else
       execute ./configure --prefix="${WORKSPACE}" --enable-static --enable-pic
     fi


### PR DESCRIPTION
Currently this clobbers any existing CXXFLAGS when configuring x264, this will remove any user specified optimisation or hardening flags. Changing it to prepend to any potential existing CXXFLAG.