### PR TITLE
Add Rocky linux 8 support with cuda 11.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
 
   build-cuda-rocky-docker:
     name: build in Rockylinux docker with cuda
-    runs-on: rockylinux-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,30 @@ jobs:
         run: |
           docker run --rm ffmpeg:cuda-ubuntu -buildconf
 
+  build-cuda-rocky-docker:
+    name: build in Rockylinux docker with cuda
+    runs-on: rockylinux-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: pull base image
+        id: cuda_centos_pull
+        run: |
+          docker pull nvidia/cuda:11.6.0-devel-centos8
+          docker pull rockylinux:8
+      - name: run if cuda_centos_pull failed
+        if: failure() && steps.cuda_centos_pull.outcome == 'failure'
+        run: |
+          docker pull nvidia/cuda:11.6.0-devel-centos8
+          docker pull rockylinux:8
+      - name: build ffmpeg
+        run: |
+          docker build -t ffmpeg:cuda-rocky -f cuda-rocky.dockerfile .
+      - name: test run ffmepg
+        run: |
+          docker run --rm ffmpeg:cuda-rocky -buildconf
+
   build-full-static:
     name: full static build in docker
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ with https://github.com/markus-perl/ffmpeg-build-script/actions to make sure eve
 ### Linux
 
 * Debian >= Buster, Ubuntu => Focal Fossa, other Distributions might work too
+* Rocky Linux 8
 * A development environment and curl is required
 
 ```bash
@@ -151,7 +152,7 @@ These builds are always built with the --enable-gpl-and-non-free switch, as CUDA
 ```bash
 export DOCKER_BUILDKIT=1
 
-## Set the DIST (`ubuntu` or `centos`) and VER (ubuntu: `16.04` , `18.04`, `20.04` or centos: `7`, `8`) environment variables to select the preferred Docker base image.
+## Set the DIST (`ubuntu` or `rocky`) and VER (ubuntu: `16.04` , `18.04`, `20.04` or rocky: `8`) environment variables to select the preferred Docker base image.
 $ export DIST=centos
 $ export VER=8
 

--- a/cuda-rocky.dockerfile
+++ b/cuda-rocky.dockerfile
@@ -1,0 +1,72 @@
+ARG VER=8
+
+FROM nvidia/cuda:11.6.0-devel-centos${VER} AS build
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+
+
+# Fix EOL Mirror issue
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+# Pick one of these mirrors that works. vault.centos.org was giving me timeout issues
+# RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+# RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://linuxsoft.cern.ch/centos-vault/|g' /etc/yum.repos.d/CentOS-Linux-*
+# RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://archive.kernel.org/centos-vault/|g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://mirror.nsc.liu.se/centos-store|g' /etc/yum.repos.d/CentOS-Linux-*
+
+# upgrade to Rocky Linux 8
+RUN dnf install -y ncurses \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf \
+ && rm -rf /var/cache/yum \
+ && dnf install -y dnf-plugins-core \
+ && dnf -y update
+ 
+WORKDIR /opt/conversion_to_rocky
+RUN curl -O https://raw.githubusercontent.com/rocky-linux/rocky-tools/main/migrate2rocky/migrate2rocky.sh && \
+    chmod +x migrate2rocky.sh && \
+    bash migrate2rocky.sh  -r
+
+
+RUN yum group install -y "Development Tools" \
+    && yum install -y curl libva-devel python3 \
+    && yum install -y meson ninja-build --enablerepo=powertools \
+    && rm -rf /var/cache/yum/* /var/cache/dnf/* \
+    && yum clean all \
+    && alternatives --set python /usr/bin/python3
+
+WORKDIR /app
+COPY ./build-ffmpeg /app/build-ffmpeg
+
+RUN SKIPINSTALL=yes /app/build-ffmpeg --build --enable-gpl-and-non-free
+
+
+FROM rockylinux:${VER}
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+
+# install va-driver
+RUN yum install -y libva \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all
+
+# Copy libnpp
+COPY --from=build /usr/local/cuda-11.6/targets/x86_64-linux/lib/libnppc.so.11 /lib64/libnppc.so.11
+COPY --from=build /usr/local/cuda-11.6/targets/x86_64-linux/lib/libnppig.so.11 /lib64/libnppig.so.11
+COPY --from=build /usr/local/cuda-11.6/targets/x86_64-linux/lib/libnppicc.so.11 /lib64/libnppicc.so.11
+COPY --from=build /usr/local/cuda-11.6/targets/x86_64-linux/lib/libnppidei.so.11 /lib64/libnppidei.so.11
+COPY --from=build /usr/local/cuda-11.6/targets/x86_64-linux/lib/libnppif.so.11 /lib64/libnppif.so.11
+
+# Copy ffmpeg
+COPY --from=build /app/workspace/bin/ffmpeg /usr/bin/ffmpeg
+COPY --from=build /app/workspace/bin/ffprobe /usr/bin/ffprobe
+COPY --from=build /app/workspace/bin/ffplay /usr/bin/ffplay
+
+# Check shared library
+RUN ldd /usr/bin/ffmpeg
+RUN ldd /usr/bin/ffprobe
+RUN ldd /usr/bin/ffplay
+
+CMD         ["--help"]
+ENTRYPOINT  ["/usr/bin/ffmpeg"]


### PR DESCRIPTION
Hi, after some time I'm working again in this project. 

This adds support for Rocky Linux 8, the spiritual successor of CentOS 8,  It uses the same image from Nvidia, but updates the CentOS image to rocky Linux. With this fix, now it can continue to connect and get the binaries to build FFmpeg.

The fix comes from this thread https://gitlab.com/nvidia/container-images/cuda/-/issues/149

I will create as a draft because it just came from the oven and I need to test it before