### PR TITLE
Add GnuTLS support for LGPL FFmpeg builds

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -400,6 +400,31 @@ if $NONFREE_AND_GPL; then
     build_done "openssl" "1.1.1m"
   fi
   CONFIGURE_OPTIONS+=("--enable-openssl")
+else
+  if build "gmp" "6.2.1"; then
+    download "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz"
+    execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+    execute make -j $MJOBS
+    execute make install
+    build_done "gmp" "6.2.1"
+  fi
+
+  if build "nettle" "3.8"; then
+    download "https://ftp.gnu.org/gnu/nettle/nettle-3.8.tar.gz"
+    execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static --disable-openssl --disable-documentation --libdir="${WORKSPACE}"/lib CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+    execute make -j $MJOBS
+    execute make install
+    build_done "nettle" "3.8"
+  fi
+
+  if build "gnutls" "3.6.16"; then
+    download "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.16.tar.xz"
+    execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static --disable-doc --disable-tools --disable-cxx --disable-tests --disable-gtk-doc-html --disable-libdane --disable-nls --enable-local-libopts --disable-guile --with-included-libtasn1 --with-included-unistring --without-p11-kit CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+    execute make -j $MJOBS
+    execute make install
+    build_done "gnutls" "3.6.16"
+  fi
+  CONFIGURE_OPTIONS+=("--enable-gmp" "--enable-gnutls")
 fi
 
 if build "cmake" "3.23.1"; then


### PR DESCRIPTION
Since OpenSSL is licensed under the OpenSSL License and the SSLeay license in version 1.1.1 and earlier, it's excluded from the default FFmpeg build as those licenses are incompatible with the GPL (although possibly compatible with the LGPL according to the [FFmpeg documentation](https://ffmpeg.org/doxygen/trunk/md_LICENSE.html)).

As an alternative, GnuTLS, is an open source TLS/SSL library that is licensed under LGPL 2.1 or later.  It requires GMP, which is licensed under LGPL 3 (or GPL 2) and Nettle, which is licensed under LGPL 3.

This makes GnuTLS (and its dependencies) suitable to be part of a LGPL 3 build of FFmpeg without worrying over license compatibility.

Alternatively, updating OpenSSL to version 3.0 changes its license to the Apache 2.0 license, which is compatible with both the GPL and LGPL.