### PR TITLE
Set Ubuntu version to 22.04 LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 AS build
+FROM ubuntu:22.04 AS build
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -13,7 +13,7 @@ COPY ./build-ffmpeg /app/build-ffmpeg
 
 RUN SKIPINSTALL=yes /app/build-ffmpeg --build
 
-FROM ubuntu:22.10
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Ubuntu 22.10 is out of support, this sets the version to 22.04 which is LTS and supported until April 2027. Another option would be to update to 23.04, which would have support to July 2024 (I think).

Looks like the other Dockerfiles are already on 22.04.