### PR TITLE
Removal of SvtAv1Dec

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -520,7 +520,7 @@ if command_exists "python3"; then
   fi
 fi
 
-if build "svtav1" "2.1.0"; then
+if build "svtav1" "2.1.2"; then
   # Last known working commit which passed CI Tests from HEAD branch
   download "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v$CURRENT_PACKAGE_VERSION/SVT-AV1-v$CURRENT_PACKAGE_VERSION.tar.gz" "svtav1-$CURRENT_PACKAGE_VERSION.tar.gz"
   cd "${PACKAGES}"/svtav1-$CURRENT_PACKAGE_VERSION//Build/linux || exit
@@ -528,7 +528,6 @@ if build "svtav1" "2.1.0"; then
   execute make -j $MJOBS
   execute make install
   execute cp SvtAv1Enc.pc "${WORKSPACE}/lib/pkgconfig/"
-  execute cp SvtAv1Dec.pc "${WORKSPACE}/lib/pkgconfig/"
   build_done "svtav1" $CURRENT_PACKAGE_VERSION
 fi
 CONFIGURE_OPTIONS+=("--enable-libsvtav1")


### PR DESCRIPTION
SvtAv1Dec has been removed from the project.

This removes the decoder and set the current 2.1.2 version.