### PR TITLE
Adding libharfbuzz, without it there's no filter drawtext

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -949,6 +949,7 @@ if build "FreeType2" "2.13.3"; then
 fi
 
 CONFIGURE_OPTIONS+=("--enable-libfreetype")
+CONFIGURE_OPTIONS+=("--enable-libharfbuzz")
 
 if $NONFREE_AND_GPL; then
   if build "srt" "1.5.4"; then


### PR DESCRIPTION
Without libharfbuzz, ffmpeg does not provide a wide using filter "drawtext", so I added --enable-libharfbuzz to the build script.