### PR TITLE
deviceQuery compiler fails due to requiring cmake prior to make

### DIFF
--- a/cuda-ubuntu.dockerfile
+++ b/cuda-ubuntu.dockerfile
@@ -9,7 +9,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,video
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install build-essential curl ca-certificates libva-dev \
-        python3 python-is-python3 ninja-build meson git curl \
+        python3 python-is-python3 ninja-build meson git curl cmake \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 
@@ -17,7 +17,7 @@ RUN apt-get update \
 RUN mkdir -p /code && \
     git clone --depth 1 https://github.com/NVIDIA/cuda-samples.git /code/cuda-samples && \
     cd /code/cuda-samples/Samples/1_Utilities/deviceQuery && \
-    make && \
+    cmake . && make && \
     mv deviceQuery /usr/local/bin
 
 WORKDIR /app


### PR DESCRIPTION
Update cuda-ubuntu.dockerfile with install cmake.
Also prior to make, run 'cmake .' to create the make file, otherwise make command fails.
I've tested this successfully on ubuntu 24.04, but it really doesn't matter what version of Ubuntu, this is required.