### PR TITLE
Switch to GNU mirrors for GNU dependencies downloads

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -418,7 +418,7 @@ if build "zlib" "1.3.1"; then
 fi
 
 if build "m4" "1.4.19"; then
-  download "https://ftp.gnu.org/gnu/m4/m4-$CURRENT_PACKAGE_VERSION.tar.gz"
+  download "https://ftpmirror.gnu.org/gnu/m4/m4-$CURRENT_PACKAGE_VERSION.tar.gz"
   execute ./configure --prefix="${WORKSPACE}"
   execute make -j $MJOBS
   execute make install
@@ -426,7 +426,7 @@ if build "m4" "1.4.19"; then
 fi
 
 if build "autoconf" "2.72"; then
-  download "https://ftp.gnu.org/gnu/autoconf/autoconf-$CURRENT_PACKAGE_VERSION.tar.gz"
+  download "https://ftpmirror.gnu.org/gnu/autoconf/autoconf-$CURRENT_PACKAGE_VERSION.tar.gz"
   execute ./configure --prefix="${WORKSPACE}"
   execute make -j $MJOBS
   execute make install
@@ -434,7 +434,7 @@ if build "autoconf" "2.72"; then
 fi
 
 if build "automake" "1.17"; then
-  download "https://ftp.gnu.org/gnu/automake/automake-$CURRENT_PACKAGE_VERSION.tar.gz"
+  download "https://ftpmirror.gnu.org/gnu/automake/automake-$CURRENT_PACKAGE_VERSION.tar.gz"
   execute ./configure --prefix="${WORKSPACE}"
   execute make -j $MJOBS
   execute make install
@@ -468,7 +468,7 @@ if $NONFREE_AND_GPL; then
   CONFIGURE_OPTIONS+=("--enable-openssl")
 else
   if build "gmp" "6.3.0"; then
-    download "https://ftp.gnu.org/gnu/gmp/gmp-$CURRENT_PACKAGE_VERSION.tar.xz"
+    download "https://ftpmirror.gnu.org/gnu/gmp/gmp-$CURRENT_PACKAGE_VERSION.tar.xz"
     execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
     execute make -j $MJOBS
     execute make install
@@ -476,7 +476,7 @@ else
   fi
 
   if build "nettle" "3.10"; then
-    download "https://ftp.gnu.org/gnu/nettle/nettle-$CURRENT_PACKAGE_VERSION.tar.gz"
+    download "https://ftpmirror.gnu.org/gnu/nettle/nettle-$CURRENT_PACKAGE_VERSION.tar.gz"
     execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static --disable-openssl --disable-documentation --libdir="${WORKSPACE}"/lib CPPFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
     execute make -j $MJOBS
     execute make install


### PR DESCRIPTION
## Switch to GNU Mirrors for GNU dependencies downloads

### Problem

Encountered timeouts and critically low download speeds from `ftp.gnu.org` when building Docker images from CI locations in Sweden, Germany, and Cyprus. This resulted in build failures like this:

```
#9 50.56 building m4 - version 1.4.19
#9 50.56 =======================
#9 50.56 Downloading https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz as m4-1.4.19.tar.gz
#9 184.5 
#9 184.5 Failed to download https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz. Exitcode 28. Retrying in 10 seconds
#9 327.9 
#9 327.9 Failed to download https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.gz. Exitcode 28
#9 ERROR: process "/bin/sh -c SKIPINSTALL=yes /app/build-ffmpeg --build --full-static --enable-gpl-and-non-free --small" did not complete successfully: exit code: 1
```

### Solution

Switched to using GNU mirrors  `ftpmirror.gnu.org` for downloading GNU components. 

### Rationale

- GNU officially recommends using mirrors for downloads (see [GNU Mirror List documentation](https://www.gnu.org/prep/ftp.html))
- Some components in the codebase already use `ftpmirror.gnu.org`, making this change consistent with existing practices
- Mirror infrastructure provides better geographic distribution and redundancy

### Changes

Updated download URLs for the following GNU components:
- m4
- autoconf
- automake
- gmp
- nettle

All downloads now use `https://ftpmirror.gnu.org/gnu/` instead of `https://ftp.gnu.org/gnu/`.

### Testing

- Verified builds complete successfully from multiple geographic locations (Cyprus, Germany, Sweden)
- All component versions remain unchanged