### PR TITLE
Update opus to 1.6.1

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -840,7 +840,7 @@ if build "lame" "3.100"; then
 fi
 CONFIGURE_OPTIONS+=("--enable-libmp3lame")
 
-if build "opus" "1.6"; then
+if build "opus" "1.6.1"; then
   download "https://downloads.xiph.org/releases/opus/opus-$CURRENT_PACKAGE_VERSION.tar.gz"
   execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
   execute make -j $MJOBS


### PR DESCRIPTION
New minor version of Opus was released last month

https://opus-codec.org/release/stable/2026/01/14/libopus-1_6_1.html